### PR TITLE
Those Who Came Before Finally Learns to Roll Dice Properly

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,7 @@
 		"build": "deno run -A npm:vite build",
 		"preview": "deno run -A npm:vite preview",
 		"check": "deno run -A npm:@sveltejs/kit sync && deno run -A npm:svelte-check --tsconfig ./tsconfig.json",
-		"test": "deno test -A"
+		"test": "deno test"
 	},
 	"compilerOptions": {
 		"strict": true,

--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,8 @@
 		"dev": "deno run -A npm:vite dev",
 		"build": "deno run -A npm:vite build",
 		"preview": "deno run -A npm:vite preview",
-		"check": "deno run -A npm:@sveltejs/kit sync && deno run -A npm:svelte-check --tsconfig ./tsconfig.json"
+		"check": "deno run -A npm:@sveltejs/kit sync && deno run -A npm:svelte-check --tsconfig ./tsconfig.json",
+		"test": "deno test -A"
 	},
 	"compilerOptions": {
 		"strict": true,
@@ -25,7 +26,8 @@
 		"@tailwindcss/typography": "npm:@tailwindcss/typography@~0.5.15",
 		"daisyui": "npm:daisyui@5",
 		"svelte-check": "npm:svelte-check@4",
-		"typescript": "npm:typescript@5"
+		"typescript": "npm:typescript@5",
+		"@std/assert": "jsr:@std/assert@^1.0.19"
 	},
 	"fmt": {
 		"useTabs": true,

--- a/deno.lock
+++ b/deno.lock
@@ -1,6 +1,8 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
     "npm:@deno/svelte-adapter@~0.1.1": "0.1.1_@sveltejs+kit@2.52.0__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.51.2____acorn@8.15.0___vite@7.3.1____picomatch@4.0.3__svelte@5.51.2___acorn@8.15.0__typescript@5.9.3__vite@7.3.1___picomatch@4.0.3__acorn@8.15.0_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.51.2___acorn@8.15.0__vite@7.3.1___picomatch@4.0.3_svelte@5.51.2__acorn@8.15.0_typescript@5.9.3_vite@7.3.1__picomatch@4.0.3",
     "npm:@sveltejs/kit@*": "2.52.0_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.51.2___acorn@8.15.0__vite@7.3.1___picomatch@4.0.3_svelte@5.51.2__acorn@8.15.0_typescript@5.9.3_vite@7.3.1__picomatch@4.0.3_acorn@8.15.0",
     "npm:@sveltejs/kit@^2.22.0": "2.52.0_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.51.2___acorn@8.15.0__vite@7.3.1___picomatch@4.0.3_svelte@5.51.2__acorn@8.15.0_typescript@5.9.3_vite@7.3.1__picomatch@4.0.3_acorn@8.15.0",
@@ -16,6 +18,17 @@
     "npm:typescript@5": "5.9.3",
     "npm:vite@*": "7.3.1_picomatch@4.0.3",
     "npm:vite@7": "7.3.1_picomatch@4.0.3"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    }
   },
   "npm": {
     "@deno/experimental-route-config@0.0.5": {
@@ -922,6 +935,7 @@
   },
   "workspace": {
     "dependencies": [
+      "jsr:@std/assert@^1.0.19",
       "npm:@deno/svelte-adapter@~0.1.1",
       "npm:@sveltejs/kit@^2.22.0",
       "npm:@sveltejs/vite-plugin-svelte@6",

--- a/docs/roadmaps/mvp.md
+++ b/docs/roadmaps/mvp.md
@@ -6,7 +6,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 |          | Status                  | Next Up           | Blocked           |
 | -------- | ----------------------- | ----------------- | ----------------- |
-| **FD**   | In progress             | 1FD.6             | —                 |
+| **FD**   | In progress             | 1FD.10            | —                 |
 | **GN**   | Not started             | —                 | 1FD.10            |
 | **WS**   | Not started             | —                 | 2GN.56            |
 | **UI**   | Not started             | —                 | 3WS.15            |
@@ -48,13 +48,6 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 <a name="m1-todo"><h4>To Do (Milestone 1)</h4></a>
 
-**Seeded PRNG**
-
-- [ ] 1FD.6. Implement `src/lib/engine/prng.ts` — xoshiro128** algorithm, `createPrng(seed: string): () => number`
-- [ ] 1FD.7. Write `weightedSelect(items, prng)` utility (reused across pipeline)
-- [ ] 1FD.8. Write PRNG determinism test — same seed → identical sequence
-- [ ] 1FD.9. Write PRNG distribution test — output approximately uniform over large sample
-
 **Type system**
 
 - [ ] 1FD.10. `src/lib/types/grammar.ts` — `GrammarRule`, `GrammarOption`, `ArrangementPattern`, `AccumulationConstraints`, `AttachmentType`
@@ -84,8 +77,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 **Test infrastructure**
 
-- [ ] 1FD.34. Configure `deno test`, verify runner executes against engine skeleton
-- [ ] 1FD.35. Create test fixture helpers — mock culture, mock world seed, mock artefact factories
+- [ ] 1FD.35. Create test fixture helpers — mock culture, mock world seed, mock artefact factories (partially done: `tests/fixtures/world.ts` has `mockWorldSeed`; mock culture blocked on 1FD.14/1FD.12/1FD.16, mock artefact blocked on 1FD.11/1FD.10/1FD.12 — none of those types exist yet)
 
 **Project Explorer shell**
 
@@ -105,6 +97,17 @@ description: MVP implementation roadmap from foundation through NPC social syste
 - [x] 1FD.3. Strip Node tooling (`.prettierrc`, `.prettierignore`, `.npmrc`)
 - [x] 1FD.4. Verify npm deps via `npm:` specifiers (Svelte 5, SvelteKit 2, Vite 7, Tailwind 4, DaisyUI 5)
 - [x] 1FD.5. Verify `deno task dev` serves app, `deno task check` passes
+
+**Seeded PRNG**
+
+- [x] 1FD.6. Implement `src/lib/engine/prng.ts` — xoshiro128** algorithm, `createPrng(seed: string): () => number`
+- [x] 1FD.7. Write `weightedSelect(items, prng)` utility (reused across pipeline)
+- [x] 1FD.8. Write PRNG determinism test — same seed → identical sequence
+- [x] 1FD.9. Write PRNG distribution test — output approximately uniform over large sample
+
+**Test infrastructure**
+
+- [x] 1FD.34. Configure `deno test`, verify runner executes against engine skeleton (`deno task test` wired in `deno.json`; `@std/assert@^1.0.19` added; `tsconfig.json` excludes `*.test.ts` from `svelte-check` since Deno test files use `Deno.ns`/`jsr:` specifiers svelte-check can't resolve)
 </details>
 
 <details>
@@ -665,11 +668,11 @@ graph TD
     m1A{"`<h3>1A</h3>Deno build configured`"}:::done
     m1B{"`<h3>1B</h3>All types created`"}:::mile
     m1C{"`<h3>1C</h3>M1 Explorer`"}:::mile
-    m1D{"`<h3>1D</h3>Random Generation Util`"}:::mile
-    1FD.6["`*1FD.6*<br/>PRNG xoshiro128**`"]:::open
-    1FD.7["`*1FD.7*<br/>weightedSelect util`"]:::blocked
-    1FD.8["`*1FD.8*<br/>PRNG determinism test`"]:::blocked
-    1FD.9["`*1FD.9*<br/>PRNG distribution test`"]:::blocked
+    m1D{"`<h3>1D</h3>Random Generation Util`"}:::done
+    1FD.6["`*1FD.6*<br/>PRNG xoshiro128**`"]:::done
+    1FD.7["`*1FD.7*<br/>weightedSelect util`"]:::done
+    1FD.8["`*1FD.8*<br/>PRNG determinism test`"]:::done
+    1FD.9["`*1FD.9*<br/>PRNG distribution test`"]:::done
     1FD.10["`*1FD.10*<br/>types/grammar.ts`"]:::open
     1FD.11["`*1FD.11*<br/>types/artefact.ts`"]:::blocked
     1FD.12["`*1FD.12*<br/>types/tags.ts`"]:::open
@@ -694,8 +697,8 @@ graph TD
     1FD.31["`*1FD.31*<br/>types/description.ts`"]:::blocked
     1FD.32["`*1FD.32*<br/>types/visibility.ts`"]:::blocked
     1FD.33["`*1FD.33*<br/>types/save.ts`"]:::blocked
-    1FD.34["`*1FD.34*<br/>Configure deno test`"]:::open
-    1FD.35["`*1FD.35*<br/>Test fixture helpers`"]:::blocked
+    1FD.34["`*1FD.34*<br/>Configure deno test`"]:::done
+    1FD.35["`*1FD.35*<br/>Test fixture helpers (partial)`"]:::open
     1FD.36["`*1FD.36*<br/>Explorer route + layout`"]:::open
     1FD.37["`*1FD.37*<br/>Explorer seed input`"]:::blocked
     1FD.38["`*1FD.38*<br/>Explorer PRNG display`"]:::blocked

--- a/src/lib/engine/prng.test.ts
+++ b/src/lib/engine/prng.test.ts
@@ -1,0 +1,137 @@
+/// <reference lib="deno.ns" />
+import { assert, assertEquals, assertNotEquals } from '@std/assert';
+import { createPrng, weightedSelect } from './prng.ts';
+import { mockWorldSeed } from '../../../tests/fixtures/world.ts';
+
+function drawSequence(prng: () => number, count: number): number[] {
+	return Array.from({ length: count }, () => prng());
+}
+
+Deno.test('createPrng: same seed produces identical sequence', () => {
+	const first = createPrng('test-seed-42');
+	const second = createPrng('test-seed-42');
+
+	assertEquals(drawSequence(first, 50), drawSequence(second, 50));
+});
+
+Deno.test('createPrng: different seeds produce different sequences', () => {
+	const a = createPrng('test-seed-42');
+	const b = createPrng('test-seed-43');
+
+	assertNotEquals(drawSequence(a, 10), drawSequence(b, 10));
+});
+
+Deno.test('createPrng: output stays within [0, 1)', () => {
+	const prng = createPrng('range-check');
+
+	for (const value of drawSequence(prng, 10_000)) {
+		assert(value >= 0 && value < 1, `value out of range: ${value}`);
+	}
+});
+
+Deno.test('createPrng: output is approximately uniform over a large sample', () => {
+	const prng = createPrng('distribution-test');
+	const sampleSize = 100_000;
+	const values = drawSequence(prng, sampleSize);
+
+	const mean = values.reduce((sum, value) => sum + value, 0) / sampleSize;
+	assert(
+		Math.abs(mean - 0.5) < 0.01,
+		`expected mean close to 0.5, got ${mean}`,
+	);
+
+	const bucketCount = 10;
+	const buckets = new Array(bucketCount).fill(0);
+	for (const value of values) {
+		buckets[Math.min(bucketCount - 1, Math.floor(value * bucketCount))]++;
+	}
+
+	const expectedPerBucket = sampleSize / bucketCount;
+	for (const [index, count] of buckets.entries()) {
+		const deviation = Math.abs(count - expectedPerBucket) / expectedPerBucket;
+		assert(
+			deviation < 0.05,
+			`bucket ${index} deviates from uniform by ${(deviation * 100).toFixed(1)}% (count=${count})`,
+		);
+	}
+});
+
+Deno.test('weightedSelect: same seed reproduces the same selection sequence', () => {
+	const items = [
+		{ label: 'common', weight: 8 },
+		{ label: 'rare', weight: 2 },
+	];
+
+	const first = createPrng('weighted-repeat');
+	const second = createPrng('weighted-repeat');
+
+	const firstRun = Array.from(
+		{ length: 20 },
+		() => weightedSelect(items, first, (item) => item.weight).label,
+	);
+	const secondRun = Array.from(
+		{ length: 20 },
+		() => weightedSelect(items, second, (item) => item.weight).label,
+	);
+
+	assertEquals(firstRun, secondRun);
+});
+
+Deno.test('weightedSelect: observed frequencies track configured weights', () => {
+	const items = [
+		{ label: 'common', weight: 8 },
+		{ label: 'rare', weight: 2 },
+	];
+	const prng = createPrng('weighted-distribution');
+	const draws = 10_000;
+
+	const counts = { common: 0, rare: 0 };
+	for (let i = 0; i < draws; i++) {
+		counts[weightedSelect(items, prng, (item) => item.weight).label as 'common' | 'rare']++;
+	}
+
+	const commonRatio = counts.common / draws;
+	assert(
+		Math.abs(commonRatio - 0.8) < 0.03,
+		`expected ~80% common, got ${(commonRatio * 100).toFixed(1)}% (counts=${
+			JSON.stringify(counts)
+		})`,
+	);
+});
+
+Deno.test('weightedSelect: falls back to uniform selection when total weight is zero', () => {
+	const items = [{ id: 'a', weight: 0 }, { id: 'b', weight: 0 }];
+	const prng = createPrng('zero-weight');
+
+	const seen = new Set<string>();
+	for (let i = 0; i < 50; i++) {
+		seen.add(weightedSelect(items, prng, (item) => item.weight).id);
+	}
+
+	assert(seen.size > 1, 'expected both items to be selectable under zero total weight');
+});
+
+Deno.test('weightedSelect: throws on empty items', () => {
+	const prng = createPrng('empty-check');
+
+	let threw = false;
+	try {
+		weightedSelect([], prng, () => 1);
+	} catch {
+		threw = true;
+	}
+
+	assert(threw, 'expected weightedSelect to throw on an empty items array');
+});
+
+Deno.test('mockWorldSeed: same raw seed produces a deterministic prng', () => {
+	const a = mockWorldSeed('fixture-seed');
+	const b = mockWorldSeed('fixture-seed');
+
+	assertEquals(drawSequence(a.prng, 20), drawSequence(b.prng, 20));
+});
+
+Deno.test('mockWorldSeed: defaults to a stable raw seed', () => {
+	const seed = mockWorldSeed();
+	assertEquals(seed.raw, 'test-seed');
+});

--- a/src/lib/engine/prng.ts
+++ b/src/lib/engine/prng.ts
@@ -1,0 +1,117 @@
+/**
+ * Seeded pseudo-random number generation.
+ *
+ * The engine's determinism guarantee rests entirely on this module: the same seed string must
+ * produce the same sequence of numbers, forever, on every platform. Nothing here touches the
+ * framework or the browser — pure arithmetic only (doc 08 §2.1, the engine boundary).
+ */
+
+/**
+ * xmur3 string hash — turns an arbitrary seed string into a stream of well-mixed 32-bit integers.
+ * Used only to seed the xoshiro128** state; it is not itself the generator.
+ *
+ * Reference: https://github.com/bryc/code/blob/master/jshash/PRNGs.md
+ */
+function xmur3(seed: string): () => number {
+	let hash = 1779033703 ^ seed.length;
+	for (let index = 0; index < seed.length; index++) {
+		hash = Math.imul(hash ^ seed.charCodeAt(index), 3432918353);
+		hash = (hash << 13) | (hash >>> 19);
+	}
+
+	return (): number => {
+		hash = Math.imul(hash ^ (hash >>> 16), 2246822507);
+		hash = Math.imul(hash ^ (hash >>> 13), 3266489909);
+		hash ^= hash >>> 16;
+		return hash >>> 0;
+	};
+}
+
+/** 32-bit left rotation, kept in unsigned range. */
+function rotl(value: number, bits: number): number {
+	return ((value << bits) | (value >>> (32 - bits))) >>> 0;
+}
+
+/**
+ * Creates a deterministic pseudo-random number generator from a seed string.
+ *
+ * Algorithm: xoshiro128** (Blackman & Vigna), seeded via xmur3. Same seed produces the same
+ * infinite sequence of floats in `[0, 1)`, on every call, every run, every machine.
+ *
+ * @param seed - Any string. Distinct seeds diverge immediately; the same seed always replays
+ *   the same sequence from the start.
+ * @returns A generator function; each call advances the state and returns the next float.
+ */
+export function createPrng(seed: string): () => number {
+	const nextSeedWord = xmur3(seed);
+
+	// Four 32-bit state words. xoshiro128** is defined as degenerate on an all-zero state, which
+	// xmur3 output makes vanishingly unlikely — but guard it anyway so a pathological seed can
+	// never silently produce a constant sequence.
+	let state0 = nextSeedWord();
+	let state1 = nextSeedWord();
+	let state2 = nextSeedWord();
+	let state3 = nextSeedWord();
+
+	if ((state0 | state1 | state2 | state3) === 0) {
+		state0 = 1;
+	}
+
+	return function next(): number {
+		const result = Math.imul(rotl(Math.imul(state1, 5), 7), 9) >>> 0;
+
+		const t = (state1 << 9) >>> 0;
+
+		state2 ^= state0;
+		state3 ^= state1;
+		state1 ^= state2;
+		state0 ^= state3;
+
+		state2 ^= t;
+		state3 = rotl(state3, 11);
+
+		return result / 4294967296; // 2**32 — normalises to [0, 1)
+	};
+}
+
+/**
+ * Selects one item from a weighted list using a seeded PRNG.
+ *
+ * Weight extraction is delegated to a callback rather than a fixed field name, since callers in
+ * the generation pipeline use differently-shaped items (e.g. `{ effectiveWeight }` for grammar
+ * options, `{ weight }` for materials — doc 05 §4, §6).
+ *
+ * @param items - Candidates to select from. Must be non-empty.
+ * @param prng - A generator from `createPrng`, or any `() => number` in `[0, 1)`.
+ * @param getWeight - Returns a non-negative weight for an item. Items with zero total weight
+ *   fall back to a uniform draw, so a bad weighting table degrades gracefully rather than
+ *   crashing or silently always picking the first item.
+ * @returns The selected item.
+ */
+export function weightedSelect<T>(
+	items: readonly T[],
+	prng: () => number,
+	getWeight: (item: T) => number,
+): T {
+	if (items.length === 0) {
+		throw new Error('weightedSelect: items must not be empty');
+	}
+
+	const totalWeight = items.reduce((sum, item) => sum + Math.max(0, getWeight(item)), 0);
+
+	if (totalWeight <= 0) {
+		const index = Math.floor(prng() * items.length);
+		return items[Math.min(index, items.length - 1)];
+	}
+
+	let remaining = prng() * totalWeight;
+	for (const item of items) {
+		remaining -= Math.max(0, getWeight(item));
+		if (remaining <= 0) {
+			return item;
+		}
+	}
+
+	// Floating-point drift can leave a sliver of `remaining` unconsumed; the last item covers it.
+	return items[items.length - 1];
+}

--- a/src/lib/engine/prng.ts
+++ b/src/lib/engine/prng.ts
@@ -97,7 +97,8 @@ export function weightedSelect<T>(
 		throw new Error('weightedSelect: items must not be empty');
 	}
 
-	const totalWeight = items.reduce((sum, item) => sum + Math.max(0, getWeight(item)), 0);
+	const weights = items.map((item) => Math.max(0, getWeight(item)));
+	const totalWeight = weights.reduce((sum, weight) => sum + weight, 0);
 
 	if (totalWeight <= 0) {
 		const index = Math.floor(prng() * items.length);
@@ -105,10 +106,10 @@ export function weightedSelect<T>(
 	}
 
 	let remaining = prng() * totalWeight;
-	for (const item of items) {
-		remaining -= Math.max(0, getWeight(item));
+	for (let i = 0; i < items.length; i++) {
+		remaining -= weights[i];
 		if (remaining <= 0) {
-			return item;
+			return items[i];
 		}
 	}
 

--- a/tests/fixtures/world.ts
+++ b/tests/fixtures/world.ts
@@ -13,7 +13,7 @@ import { createPrng } from '../../src/lib/engine/prng.ts';
  * `src/lib/types/world.ts` (roadmap task 1FD.14) doesn't exist yet — swap this for the real type
  * import once that task lands.
  */
-interface MockWorldSeed {
+export interface MockWorldSeed {
 	raw: string;
 	prng: () => number;
 }

--- a/tests/fixtures/world.ts
+++ b/tests/fixtures/world.ts
@@ -1,0 +1,36 @@
+/**
+ * Test fixtures for world-level types (doc 08 §5, roadmap task 1FD.35).
+ *
+ * Consumed as `import * as fixtures from '../fixtures/world'` per the project's fixtures
+ * convention. Only `mockWorldSeed` is implemented today — it's the one fixture that needs no
+ * unbuilt domain types (see the TODOs below for what blocks the other two).
+ */
+
+import { createPrng } from '../../src/lib/engine/prng.ts';
+
+/**
+ * Structural stand-in for `WorldSeed` (doc 05 §2). Declared locally rather than imported because
+ * `src/lib/types/world.ts` (roadmap task 1FD.14) doesn't exist yet — swap this for the real type
+ * import once that task lands.
+ */
+interface MockWorldSeed {
+	raw: string;
+	prng: () => number;
+}
+
+/**
+ * Builds a mock `WorldSeed`: a raw seed string plus its deterministic PRNG. This is the only
+ * fixture in 1FD.35 buildable before the type system exists, since `WorldSeed` needs nothing
+ * beyond `createPrng` (1FD.6).
+ *
+ * @param raw - Seed string. Defaults to a fixed value so callers get determinism for free.
+ */
+export function mockWorldSeed(raw = 'test-seed'): MockWorldSeed {
+	return { raw, prng: createPrng(raw) };
+}
+
+// TODO(1FD.35): mockCulture — blocked on Culture/CulturalProfile (1FD.14), MaterialTag (1FD.12),
+// SiteType/DepositionType (1FD.16). None of these types exist in src/lib/types/ yet.
+
+// TODO(1FD.35): mockArtefact — blocked on NormalisedArtefact/ClassifiedArtefact (1FD.11),
+// ArrangementPattern/AttachmentType (1FD.10), MaterialTag (1FD.12). None of these types exist yet.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,10 @@
 	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
 		"strict": true,
-		"skipLibCheck": true
-	}
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true
+	},
+	// *.test.ts files are Deno-only (Deno.test, deno.ns lib, jsr: specifiers) and never bundled
+	// by Vite, so svelte-check shouldn't type-check them — `deno task test` covers them instead.
+	"exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Overview
Adds the project's seeded pseudo-random number generator and wires up a test runner to prove it works — the deterministic foundation every future generation stage (grammar expansion, material selection, culture bias) depends on. Also wires up `deno test` for the first time and lands one buildable fixture ahead of the type system. Covers roadmap tasks 1FD.6, 1FD.7, 1FD.8, 1FD.9, 1FD.34, and a partial 1FD.35.

## Summary
Picture an archaeological dig where, until now, every artefact was pulled out of the ground by a slightly drunk excavator who couldn't remember what he dug up yesterday. This PR sobers him up and gives him a logbook: same seed, same dig, same finds, every single time — forever. He can also now weigh his shovel choices instead of grabbing whichever one's nearest.

> [!TIP]
> Run `deno task test` after pulling this down to see the new suite pass. No other action needed — the `test` task and `@std/assert` dependency are already wired into `deno.json`.

---
## Changes

<details>
<summary><strong>Engine: seeded PRNG (1FD.6, 1FD.7)</strong></summary>

- `src/lib/engine/prng.ts` — `createPrng(seed: string): () => number` using xoshiro128** (seeded via xmur3 string hashing); returns floats in `[0, 1)`
- `weightedSelect<T>` — generic weighted-choice helper taking a weight-accessor callback, so it works with the differently-shaped items used across the generation pipeline (doc 05 §4/§6)

</details>

<details>
<summary><strong>Test infrastructure (1FD.34)</strong></summary>

- `deno.json` — adds a `test` task (`deno test -A`) and the `@std/assert@^1.0.19` import; neither existed before this branch
- `tsconfig.json` — adds `allowImportingTsExtensions` (Deno requires explicit `.ts` extensions in imports) and excludes `*.test.ts` from `svelte-check`'s scope, since Deno-only syntax (`Deno.test`, `deno.ns` lib, `jsr:` specifiers) isn't resolvable by that toolchain
- `src/lib/engine/prng.test.ts` — 10 tests covering determinism, cross-seed divergence, output range, distribution uniformity, and `weightedSelect` behaviour (reproducibility, frequency tracking, zero-weight fallback, empty-array guard)

</details>

<details>
<summary><strong>Test fixtures (1FD.35, partial)</strong></summary>

- `tests/fixtures/world.ts` — `mockWorldSeed()` factory, the one of three planned fixtures buildable today since `WorldSeed` needs nothing but `createPrng`
- Mock culture and mock artefact factories are stubbed with `TODO`s naming their exact blockers (1FD.11/1FD.14/1FD.12/1FD.16 — none of those types exist yet)

</details>

<details>
<summary><strong>Documentation</strong></summary>

- `docs/roadmaps/mvp.md` — ticks off 1FD.6, 1FD.7, 1FD.8, 1FD.9, 1FD.34; annotates 1FD.35 as partial; moves Milestone 1's "Next Up" to 1FD.10; updates the Mermaid progress graph

</details>

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic seeded random number generation and weighted selection utilities for more predictable behavior.
  * Added a dedicated test task to run the full suite with Deno.
* **Bug Fixes**
  * Improved weighted selection behavior for empty inputs and zero/negative total weights.
  * Added safeguards to keep generated values stable and within the expected range.
* **Tests**
  * Added Deno test coverage for seeded randomness, weighting accuracy, and shared world seed fixtures.
* **Documentation**
  * Updated the MVP roadmap milestone statuses and progress map.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->