### PR TITLE
Add Grammar and Tag Type Definitions

### DIFF
--- a/docs/roadmaps/mvp.md
+++ b/docs/roadmaps/mvp.md
@@ -6,8 +6,8 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 |          | Status                  | Next Up           | Blocked           |
 | -------- | ----------------------- | ----------------- | ----------------- |
-| **FD**   | In progress             | 1FD.10            | —                 |
-| **GN**   | Not started             | —                 | 1FD.10            |
+| **FD**   | In progress             | 1FD.11            | —                 |
+| **GN**   | Not started             | 2GN.1, 2GN.2, 2GN.17, 2GN.22 | —      |
 | **WS**   | Not started             | —                 | 2GN.56            |
 | **UI**   | Not started             | —                 | 3WS.15            |
 | **KN**   | Not started             | —                 | 4UI.6             |
@@ -50,9 +50,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 **Type system**
 
-- [ ] 1FD.10. `src/lib/types/grammar.ts` — `GrammarRule`, `GrammarOption`, `ArrangementPattern`, `AccumulationConstraints`, `AttachmentType`
 - [ ] 1FD.11. `src/lib/types/artefact.ts` — `NormalisedArtefact`, `NormalisedComponent`, `Attachment`, `ObjectDimensions`, `Portability`, `InspectionDepth`, `ClassifiedArtefact`, `ExtractedFeatures`, `MaterialAssignment`, `MaterialDefinition`, `MaterialProvenance` (doc 05 §7)
-- [ ] 1FD.12. `src/lib/types/tags.ts` — `FunctionTag`, `ContextTag`, `MaterialTag`, `ClassificationRule`, `ClaimMagnitude`
 - [ ] 1FD.13. `src/lib/types/decoration.ts` — `DecorativeLayer`, `DecorativeTechnique`, surface/applied/textile element types
 - [ ] 1FD.14. `src/lib/types/world.ts` — `WorldSeed`, `WorldChronology`, `CultureTimeline`, `CulturePhase`, `PhaseCharacteristics`, `Culture`, `CulturalProfile`, `CraftInvestmentProfile`, `MotifSet`
 - [ ] 1FD.15. `src/lib/types/world.ts` — `CultureRelationship`, `RelationshipPhase`, `RelationshipDynamics`, `MaterialFlow`
@@ -77,7 +75,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 **Test infrastructure**
 
-- [ ] 1FD.35. Create test fixture helpers — mock culture, mock world seed, mock artefact factories (partially done: `tests/fixtures/world.ts` has `mockWorldSeed`; mock culture blocked on 1FD.14/1FD.12/1FD.16, mock artefact blocked on 1FD.11/1FD.10/1FD.12 — none of those types exist yet)
+- [ ] 1FD.35. Create test fixture helpers — mock culture, mock world seed, mock artefact factories (partially done: `tests/fixtures/world.ts` has `mockWorldSeed`; mock culture blocked on 1FD.14/1FD.16 — `MaterialTag` (1FD.12) now exists; mock artefact blocked on 1FD.11 — `ArrangementPattern`/`AttachmentType` (1FD.10) and `MaterialTag` (1FD.12) now exist)
 
 **Project Explorer shell**
 
@@ -104,6 +102,11 @@ description: MVP implementation roadmap from foundation through NPC social syste
 - [x] 1FD.7. Write `weightedSelect(items, prng)` utility (reused across pipeline)
 - [x] 1FD.8. Write PRNG determinism test — same seed → identical sequence
 - [x] 1FD.9. Write PRNG distribution test — output approximately uniform over large sample
+
+**Type system**
+
+- [x] 1FD.12. `src/lib/types/tags.ts` — `FunctionTag`, `ContextTag`, `MaterialTag`, `ClassificationRule`, `ClaimMagnitude` (built ahead of 1FD.10 so `grammar.ts` could import the real `MaterialTag` rather than a placeholder; `ClassificationRule.condition` types against a local `ExtractedFeatures` stand-in — `TODO(1FD.11)` — swap for the real import once `artefact.ts` lands)
+- [x] 1FD.10. `src/lib/types/grammar.ts` — `GrammarRule`, `GrammarOption`, `ArrangementPattern`, `AccumulationConstraints`, `AttachmentType` (imports `MaterialTag` from 1FD.12; `GrammarOption.expandsTo` and `.phaseModifiers` are provisional shapes, JSDoc-marked, pending 2GN.3/2GN.5)
 
 **Test infrastructure**
 
@@ -673,9 +676,9 @@ graph TD
     1FD.7["`*1FD.7*<br/>weightedSelect util`"]:::done
     1FD.8["`*1FD.8*<br/>PRNG determinism test`"]:::done
     1FD.9["`*1FD.9*<br/>PRNG distribution test`"]:::done
-    1FD.10["`*1FD.10*<br/>types/grammar.ts`"]:::open
-    1FD.11["`*1FD.11*<br/>types/artefact.ts`"]:::blocked
-    1FD.12["`*1FD.12*<br/>types/tags.ts`"]:::open
+    1FD.10["`*1FD.10*<br/>types/grammar.ts`"]:::done
+    1FD.11["`*1FD.11*<br/>types/artefact.ts`"]:::open
+    1FD.12["`*1FD.12*<br/>types/tags.ts`"]:::done
     1FD.13["`*1FD.13*<br/>types/decoration.ts`"]:::blocked
     1FD.14["`*1FD.14*<br/>types/world core`"]:::open
     1FD.15["`*1FD.15*<br/>types/world relations`"]:::blocked
@@ -746,8 +749,8 @@ m1 --> 2GN.1 & 2GN.2 & 2GN.11 & 2GN.22 & 2GN.28 & 2GN.35 & 2GN.36 & 2GN.37 & 2GN
 
 m2{{"`<h2>Milestone 2</h2>`"}}:::mile
 
-2GN.1["`*2GN.1*<br/>Primitive defs`"]:::blocked
-2GN.2["`*2GN.2*<br/>Grammar rules data`"]:::blocked
+2GN.1["`*2GN.1*<br/>Primitive defs`"]:::open
+2GN.2["`*2GN.2*<br/>Grammar rules data`"]:::open
 2GN.3["`*2GN.3*<br/>expandGrammar`"]:::blocked
 2GN.4["`*2GN.4*<br/>selectGrammarOption`"]:::blocked
 2GN.5["`*2GN.5*<br/>phaseInfluence`"]:::blocked
@@ -762,11 +765,11 @@ m2{{"`<h2>Milestone 2</h2>`"}}:::mile
 2GN.14["`*2GN.14*<br/>Ergonomic rules`"]:::blocked
 2GN.15["`*2GN.15*<br/>Material-structural compat`"]:::blocked
 2GN.16["`*2GN.16*<br/>Re-expansion loop`"]:::blocked
-2GN.17["`*2GN.17*<br/>Classification rules data`"]:::blocked
+2GN.17["`*2GN.17*<br/>Classification rules data`"]:::open
 2GN.19["`*2GN.19*<br/>extractFeatures`"]:::blocked
 2GN.20["`*2GN.20*<br/>classifyArtefact`"]:::blocked
 2GN.21["`*2GN.21*<br/>physicalLabel`"]:::blocked
-2GN.22["`*2GN.22*<br/>Material defs data`"]:::blocked
+2GN.22["`*2GN.22*<br/>Material defs data`"]:::open
 2GN.23["`*2GN.23*<br/>assignMaterial`"]:::blocked
 2GN.24["`*2GN.24*<br/>isAvailable`"]:::blocked
 2GN.25["`*2GN.25*<br/>computeMaterialWeight`"]:::blocked

--- a/src/lib/types/grammar.ts
+++ b/src/lib/types/grammar.ts
@@ -1,0 +1,130 @@
+/**
+ * Structural grammar type definitions (doc 05 §5.3–§5.5).
+ *
+ * The bottom-up component grammar produces physical structures, never functional categories
+ * (doc 05 §5.1): geometric primitives and their spatial relationships, with classification left
+ * entirely downstream. These types describe the grammar's rules and options — the weighted,
+ * culture-biased production system — plus the arrangement and accumulation constraints that keep
+ * repeated components sane. The grammar's runtime expansion lives in `engine/generation/grammar.ts`
+ * (roadmap 2GN.3–2GN.10); this module is data shapes only, no behaviour.
+ */
+
+import type { MaterialTag } from './tags.ts';
+
+/**
+ * The nine ways one component fastens to another — the terminals of the grammar's `<attachment>`
+ * production (doc 05 §5.3). Purely physical join descriptions; they carry no functional meaning.
+ */
+export type AttachmentType =
+	| 'inline'
+	| 'perpendicular'
+	| 'socketed'
+	| 'riveted'
+	| 'wrapped'
+	| 'lashed'
+	| 'hinged'
+	| 'threaded'
+	| 'friction-fit';
+
+/**
+ * How a repeated component type is laid out within a single object (doc 05 §5.5). A discriminated
+ * union on `type`: `symmetric` enumerates the exact counts that read as deliberate (e.g. `[2, 4,
+ * 6]`); every other pattern gives an inclusive `[min, max]` range instead. Keep this asymmetry —
+ * accumulation checking (roadmap 2GN.6) depends on `symmetric` being an allow-list and the rest
+ * being ranges, not a uniform shape.
+ */
+export type ArrangementPattern =
+	| { type: 'symmetric'; validCounts: number[] } // e.g. [2, 4, 6]
+	| { type: 'radial'; countRange: [number, number] } // e.g. 3–12
+	| { type: 'linear-array'; countRange: [number, number] } // e.g. 2–8
+	| { type: 'stacked'; countRange: [number, number] } // e.g. 2–5
+	| { type: 'nested'; countRange: [number, number] } // e.g. 2–4
+	| { type: 'branching'; countRange: [number, number] }; // e.g. 2–6
+
+/**
+ * Limits on how many, and how varied, the arrangement groups within one object may be (doc 05
+ * §5.5). The culture's `craftSpecialisation` determines the complexity budget that populates
+ * these fields: simple cultures get 1–2 groups and basic patterns only; sophisticated cultures
+ * unlock nesting and branching. Enforced by accumulation checking (roadmap 2GN.6).
+ */
+export interface AccumulationConstraints {
+	/** Maximum number of distinct arrangement groups in the object. From `craftSpecialisation`. */
+	maxDistinctGroups: number;
+
+	/** Maximum repeated components permitted within any single arrangement group. */
+	maxComponentsPerGroup: number;
+
+	/** When true, no two arrangement groups may repeat the same component type. */
+	noTwoGroupsSameType: boolean;
+
+	/** The arrangement patterns available under this culture's complexity budget. */
+	patterns: ArrangementPattern[];
+}
+
+/**
+ * A single production alternative for a grammar rule (doc 05 §5.4) — one thing the rule's
+ * non-terminal can expand into, with the weights that bias how often it is chosen.
+ *
+ * `selectGrammarOption` (roadmap 2GN.4) computes an effective weight per option at expansion time
+ * — starting from `baseWeight`, shifting it by `culturalModifiers` against the culture's material
+ * affinities, then scaling by `phaseInfluence` — so no precomputed effective weight is stored
+ * here; it's derived transiently and fed to `weightedSelect` (`src/lib/engine/prng.ts`) via that
+ * function's `getWeight` callback.
+ */
+export interface GrammarOption {
+	/**
+	 * The grammar symbol this option expands to — a primitive non-terminal (e.g. `'elongated'`),
+	 * another rule's `symbol`, or a terminal. `expandGrammar` (roadmap 2GN.3) resolves it: a
+	 * symbol matching another rule's `symbol` recurses; anything else is a leaf primitive whose
+	 * parameter set is defined in `data/grammars/primitives.ts` (roadmap 2GN.1).
+	 *
+	 * Provisional: doc 05 §5.4 never specifies how an option names its expansion target — this is
+	 * the minimal shape that lets `expandGrammar` do its job. Expect this to firm up at 2GN.3.
+	 */
+	expandsTo: string;
+
+	/** Baseline selection weight before cultural and phase modifiers (doc 05 §5.4). */
+	baseWeight: number;
+
+	/**
+	 * Per-material-tag weight adjustments (doc 05 §5.4). Iterated as `[MaterialTag, number]` pairs
+	 * and added to the running weight as `affinity * modifier`, so the key type matches
+	 * `CulturalProfile.materialAffinities`. A positive modifier makes the option likelier for
+	 * cultures that favour that material; negative suppresses it.
+	 */
+	culturalModifiers: Map<MaterialTag, number>;
+
+	/**
+	 * Optional phase-characteristic weight multipliers, read by `phaseInfluence` (roadmap 2GN.5)
+	 * to scale the option against a `PhaseCharacteristics` profile (doc 05 §3.2) — e.g. a
+	 * metal-bearing primitive keyed on `'technology.metallurgy'`.
+	 *
+	 * Provisional: doc 05 §5.4 shows only the call `phaseInfluence(option, phase)` and never
+	 * specifies the field it reads. Keyed by dotted `PhaseCharacteristics` path as the minimal
+	 * shape that lets 2GN.5 look up an attribute and multiply; expect this to firm up there.
+	 * Optional so an option can opt out of phase bias (`phaseInfluence` returns a neutral `1` when
+	 * absent).
+	 */
+	phaseModifiers?: Map<string, number>;
+}
+
+/**
+ * One production rule of the component grammar (doc 05 §5.3–§5.4): a non-terminal `symbol` and
+ * the weighted `options` it can expand into.
+ *
+ * `expandGrammar` (roadmap 2GN.3) receives a collection of rules and looks them up by `symbol`
+ * while walking the tree, so the symbol is the rule's identity, not decoration.
+ * `selectGrammarOption` (roadmap 2GN.4) then draws one option from `options` using the seeded
+ * PRNG.
+ */
+export interface GrammarRule {
+	/**
+	 * The non-terminal this rule defines, matching the BNF left-hand side without brackets (e.g.
+	 * `'object'`, `'component-group'`, `'primary-component'` from doc 05 §5.3). Referenced by
+	 * `GrammarOption.expandsTo` to wire the grammar together.
+	 */
+	symbol: string;
+
+	/** The production alternatives, drawn from by weighted selection (doc 05 §5.4). Non-empty. */
+	options: GrammarOption[];
+}

--- a/src/lib/types/grammar.ts
+++ b/src/lib/types/grammar.ts
@@ -69,7 +69,9 @@ export interface AccumulationConstraints {
  * — starting from `baseWeight`, shifting it by `culturalModifiers` against the culture's material
  * affinities, then scaling by `phaseInfluence` — so no precomputed effective weight is stored
  * here; it's derived transiently and fed to `weightedSelect` (`src/lib/engine/prng.ts`) via that
- * function's `getWeight` callback.
+ * function's `getWeight` callback. Doc 05 §5.4's own pseudocode shows a simplified two-arg
+ * `weightedSelect(weighted, prng)` over precomputed `{option, effectiveWeight}` pairs; the real
+ * utility takes a `getWeight` callback instead, so don't expect to find that param in the doc.
  */
 export interface GrammarOption {
 	/**

--- a/src/lib/types/tags.ts
+++ b/src/lib/types/tags.ts
@@ -95,7 +95,7 @@ export interface ExtractedFeatures {
 	overallComplexity: number;
 
 	// Dimensional — TODO(1FD.11): inline placeholders for Portability/InspectionDepth literal unions.
-	portability: 'pocketable' | 'handheld' | 'two-handed' | 'team-lift';
+	portability: 'pocketable' | 'one-hand' | 'two-hand' | 'team-lift' | 'major-effort';
 	inspectionDepth: 'full' | 'detailed' | 'observational';
 }
 

--- a/src/lib/types/tags.ts
+++ b/src/lib/types/tags.ts
@@ -1,0 +1,125 @@
+/**
+ * Classification tag vocabulary and claim-magnitude type definitions (doc 05 §4.6, §9.1–§9.2).
+ *
+ * Tags describe an artefact's function and use, scored from extracted features by rule-based
+ * classification (Stage 8, doc 05 §9). Tags are deliberately not mutually exclusive — an object
+ * can score on `weapon`, `ritual` and `elite` simultaneously; the engine never resolves the
+ * overlap, the player does. `ClaimMagnitude` is a separate axis entirely: how a published claim
+ * sits against the professional corpus (doc 05 §4.6), not a property of the artefact itself.
+ */
+
+/**
+ * What an object was FOR — its physical/social purpose (doc 05 §9.2). Not mutually exclusive with
+ * other function tags or with `ContextTag`.
+ */
+export type FunctionTag =
+	| 'weapon'
+	| 'tool'
+	| 'container'
+	| 'fastener'
+	| 'ornament'
+	| 'ritual'
+	| 'domestic'
+	| 'agricultural'
+	| 'maritime'
+	| 'funerary'
+	| 'votive'
+	| 'trade-good'
+	| 'currency';
+
+/**
+ * How an object was USED — its social register of use, distinct from `FunctionTag` (doc 05 §9.2).
+ * Not the same axis as deposition context (`DepositionType`, doc 05 §3.3) — this describes use,
+ * not how the artefact ended up in the ground.
+ */
+export type ContextTag =
+	| 'personal'
+	| 'communal'
+	| 'elite'
+	| 'utilitarian'
+	| 'ceremonial'
+	| 'everyday'
+	| 'military'
+	| 'artisanal';
+
+/**
+ * The material vocabulary components and materials are tagged with (doc 05 §9.2). Used both for
+ * `MaterialDefinition.tags` (what a material is) and `NormalisedComponent.allowedMaterialTags`
+ * (what a component can physically be made from) — see doc 05 §6.1.
+ */
+export type MaterialTag =
+	| 'bone'
+	| 'wood'
+	| 'stone'
+	| 'metal'
+	| 'clay'
+	| 'glass'
+	| 'fiber'
+	| 'leather'
+	| 'precious-stone'
+	| 'precious-metal';
+
+/**
+ * TODO(1FD.11): structural stand-in for the real `ExtractedFeatures` (doc 05 §9.1), which belongs
+ * in `src/lib/types/artefact.ts`. That file doesn't exist yet, and `ClassificationRule.condition`
+ * needs a feature shape to typecheck its predicates against — swap this for
+ * `import type { ExtractedFeatures } from './artefact.ts'` once 1FD.11 lands. Field set copied
+ * verbatim from doc 05 §9.1 so classification rule predicates (doc 05 §9.2) type-check against
+ * real field names in the meantime. `Portability` and `InspectionDepth` (also 1FD.11) are inlined
+ * as their doc-05-specified literal unions rather than imported, for the same reason.
+ */
+export interface ExtractedFeatures {
+	// Structural features
+	hasEdge: boolean;
+	edgeCount: number;
+	hasPoint: boolean;
+	hasImpactSurface: boolean;
+	hasContainer: boolean;
+	containerOpenness: number;
+	hasFasteningMechanism: boolean;
+	primaryAxisLength: 'short' | 'medium' | 'long';
+	isWearable: boolean;
+	partCount: number;
+	attachmentDiversity: number;
+
+	// Decorative features
+	decorativeLayerCount: number;
+	motifPresent: boolean;
+	motifCulturalOrigins: string[];
+	techniqueComplexity: number;
+	preciousMaterialsInDecoration: boolean;
+
+	// Combined
+	functionalComplexity: number;
+	decorativeComplexity: number;
+	overallComplexity: number;
+
+	// Dimensional — TODO(1FD.11): inline placeholders for Portability/InspectionDepth literal unions.
+	portability: 'pocketable' | 'handheld' | 'two-handed' | 'team-lift';
+	inspectionDepth: 'full' | 'detailed' | 'observational';
+}
+
+/**
+ * One feature→tag scoring contribution (doc 05 §9.2). `classifyArtefact` (roadmap 2GN.20) folds
+ * every rule whose `condition` matches into a single `Map<FunctionTag | ContextTag, number>` of
+ * accumulated scores — structural, decorative and cross-layer rules all contribute to the same
+ * map, which is how a single artefact can score on multiple, overlapping tags at once.
+ */
+export interface ClassificationRule {
+	/** Predicate over the artefact's unified extracted features (doc 05 §9.1). */
+	condition: (features: ExtractedFeatures) => boolean;
+
+	/** Tag contributions this rule adds when `condition` matches, keyed by tag with a weight. */
+	tags: Map<FunctionTag | ContextTag, number>;
+}
+
+/**
+ * How a published claim sits against the professional corpus's established consensus (doc 05
+ * §4.6) — impact and scrutiny scale together as magnitude increases, from safe agreement to a
+ * first-documented, maximally-scrutinised finding.
+ */
+export type ClaimMagnitude =
+	| 'confirmation'
+	| 'extension'
+	| 'challenge'
+	| 'novel';


### PR DESCRIPTION
# Add Grammar and Tag Type Definitions

## Overview
Adds two new type-only modules to the engine's type system: `grammar.ts` (the component grammar's rule/option/arrangement shapes) and `tags.ts` (the classification tag vocabulary and claim-magnitude axis). These are roadmap tasks 1FD.10 and 1FD.12, the next unblocked items in Milestone 1's type system work. No behaviour changes; nothing in `src/lib/engine/` or the UI reads these types yet.

Progress towards #4 (generation logic itself lands later, in roadmap 2GN.x).

## Summary
Think of it like drawing up the blueprint symbols before anyone's allowed near the actual construction site. `grammar.ts` defines the vocabulary for how components bolt, rivet, wrap and hinge onto each other, and how many rivets is "deliberate" versus "over-enthusiastic". `tags.ts` defines the sticky notes a finished artefact can wear at once: it's allowed to be a weapon, a ritual object, and someone's prized possession simultaneously, and nobody downstream has to pick just one.

> [!TIP]
> No action needed after pulling — these are new, unused type files. Nothing to run, migrate, or wire up yet.

---
## Changes

<details>
<summary><code>src/lib/types/grammar.ts</code> (new)</summary>

- `AttachmentType` — the nine physical join kinds (inline, perpendicular, socketed, riveted, wrapped, lashed, hinged, threaded, friction-fit)
- `ArrangementPattern` — discriminated union describing how repeated components lay out (symmetric counts vs. radial/linear-array/stacked/nested/branching ranges)
- `AccumulationConstraints` — per-culture limits on how many arrangement groups and repeated components an object may have
- `GrammarOption` — one weighted production alternative, including cultural and phase-based weight modifiers
- `GrammarRule` — a named non-terminal and its set of `GrammarOption`s

`GrammarOption.expandsTo` and `.phaseModifiers` are JSDoc-marked provisional, pending the expansion/phase-influence logic in roadmap tasks 2GN.3 and 2GN.5.

</details>

<details>
<summary><code>src/lib/types/tags.ts</code> (new)</summary>

- `FunctionTag` — what an object was for (weapon, tool, container, ritual, etc.)
- `ContextTag` — the social register of use (personal, elite, ceremonial, military, etc.)
- `MaterialTag` — the material vocabulary (bone, wood, stone, metal, precious-metal, etc.)
- `ClassificationRule` — a feature-predicate to tag-score contribution, used by the classification stage
- `ClaimMagnitude` — how a published claim sits against corpus consensus (confirmation → extension → challenge → novel)
- `ExtractedFeatures` — a documented stand-in for the real type landing in `artefact.ts` (task 1FD.11), tagged `TODO(1FD.11)` for the swap

</details>

<details>
<summary><code>docs/roadmaps/mvp.md</code></summary>

- Marks 1FD.10 and 1FD.12 complete, with notes on the `ExtractedFeatures` stand-in and provisional `GrammarOption` fields
- Updates the Milestone 1 status table, "Next Up" column, and dependency graph node classes for tasks these unblock (1FD.11, 2GN.1, 2GN.2, 2GN.17, 2GN.22)

</details>

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new type vocabulary for artefact classification (function, context, and material tags), plus rule and claim-magnitude definitions.
  * Added data-only TypeScript types for a bottom-up component grammar, including attachment/arrangement patterns and production rule shapes.

* **Documentation**
  * Updated the MVP roadmap and progress map to reflect current completion, open items, and adjusted dependency/blocking status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->