### PR TITLE
Add Type Definitions for Artefacts, World, Careers and Decoration

### DIFF
--- a/docs/roadmaps/mvp.md
+++ b/docs/roadmaps/mvp.md
@@ -6,7 +6,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 |          | Status                  | Next Up           | Blocked           |
 | -------- | ----------------------- | ----------------- | ----------------- |
-| **FD**   | In progress             | 1FD.11            | —                 |
+| **FD**   | In progress             | 1FD.13            | —                 |
 | **GN**   | Not started             | 2GN.1, 2GN.2, 2GN.17, 2GN.22 | —      |
 | **WS**   | Not started             | —                 | 2GN.56            |
 | **UI**   | Not started             | —                 | 3WS.15            |
@@ -50,7 +50,6 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 **Type system**
 
-- [ ] 1FD.11. `src/lib/types/artefact.ts` — `NormalisedArtefact`, `NormalisedComponent`, `Attachment`, `ObjectDimensions`, `Portability`, `InspectionDepth`, `ClassifiedArtefact`, `ExtractedFeatures`, `MaterialAssignment`, `MaterialDefinition`, `MaterialProvenance` (doc 05 §7)
 - [ ] 1FD.13. `src/lib/types/decoration.ts` — `DecorativeLayer`, `DecorativeTechnique`, surface/applied/textile element types
 - [ ] 1FD.14. `src/lib/types/world.ts` — `WorldSeed`, `WorldChronology`, `CultureTimeline`, `CulturePhase`, `PhaseCharacteristics`, `Culture`, `CulturalProfile`, `CraftInvestmentProfile`, `MotifSet`
 - [ ] 1FD.15. `src/lib/types/world.ts` — `CultureRelationship`, `RelationshipPhase`, `RelationshipDynamics`, `MaterialFlow`
@@ -75,7 +74,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 **Test infrastructure**
 
-- [ ] 1FD.35. Create test fixture helpers — mock culture, mock world seed, mock artefact factories (partially done: `tests/fixtures/world.ts` has `mockWorldSeed`; mock culture blocked on 1FD.14/1FD.16 — `MaterialTag` (1FD.12) now exists; mock artefact blocked on 1FD.11 — `ArrangementPattern`/`AttachmentType` (1FD.10) and `MaterialTag` (1FD.12) now exist)
+- [ ] 1FD.35. Create test fixture helpers — mock culture, mock world seed, mock artefact factories (partially done: `tests/fixtures/world.ts` has `mockWorldSeed`; mock culture blocked on 1FD.14/1FD.16; mock artefact unblocked — `NormalisedArtefact`/`ClassifiedArtefact` (1FD.11), `ArrangementPattern`/`AttachmentType` (1FD.10) and `MaterialTag` (1FD.12) now exist)
 
 **Project Explorer shell**
 
@@ -105,8 +104,9 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 **Type system**
 
-- [x] 1FD.12. `src/lib/types/tags.ts` — `FunctionTag`, `ContextTag`, `MaterialTag`, `ClassificationRule`, `ClaimMagnitude` (built ahead of 1FD.10 so `grammar.ts` could import the real `MaterialTag` rather than a placeholder; `ClassificationRule.condition` types against a local `ExtractedFeatures` stand-in — `TODO(1FD.11)` — swap for the real import once `artefact.ts` lands)
+- [x] 1FD.12. `src/lib/types/tags.ts` — `FunctionTag`, `ContextTag`, `MaterialTag`, `ClassificationRule`, `ClaimMagnitude` (built ahead of 1FD.10 so `grammar.ts` could import the real `MaterialTag` rather than a placeholder; `ClassificationRule.condition` typed against a local `ExtractedFeatures` stand-in until 1FD.11 landed, now imports the real type from `artefact.ts`)
 - [x] 1FD.10. `src/lib/types/grammar.ts` — `GrammarRule`, `GrammarOption`, `ArrangementPattern`, `AccumulationConstraints`, `AttachmentType` (imports `MaterialTag` from 1FD.12; `GrammarOption.expandsTo` and `.phaseModifiers` are provisional shapes, JSDoc-marked, pending 2GN.3/2GN.5)
+- [x] 1FD.11. `src/lib/types/artefact.ts` — `NormalisedArtefact`, `NormalisedComponent`, `Attachment`, `ObjectDimensions`, `Portability`, `InspectionDepth`, `ClassifiedArtefact`, `ExtractedFeatures`, `MaterialAssignment`, `MaterialDefinition`, `MaterialProvenance` (doc 05 §5.2, §6.1, §7, §9; `MaterialDefinition` has no doc 05 field shape, adopted the `{id, displayName, tags}` shape from `docs/dev/implementation/m1-artefact-generation.md` — doc 05 §15's richer geological/cultural fields deferred until `GeologicalContext`/`CulturalProfile` exist; `ClassifiedArtefact.decorativeLayers`/`.provenance` reference private `TODO(1FD.13)`/`TODO(1FD.16)` opaque `unknown` placeholders for `DecorativeLayer`/`Provenance`, owned by those tasks)
 
 **Test infrastructure**
 
@@ -677,9 +677,9 @@ graph TD
     1FD.8["`*1FD.8*<br/>PRNG determinism test`"]:::done
     1FD.9["`*1FD.9*<br/>PRNG distribution test`"]:::done
     1FD.10["`*1FD.10*<br/>types/grammar.ts`"]:::done
-    1FD.11["`*1FD.11*<br/>types/artefact.ts`"]:::open
+    1FD.11["`*1FD.11*<br/>types/artefact.ts`"]:::done
     1FD.12["`*1FD.12*<br/>types/tags.ts`"]:::done
-    1FD.13["`*1FD.13*<br/>types/decoration.ts`"]:::blocked
+    1FD.13["`*1FD.13*<br/>types/decoration.ts`"]:::open
     1FD.14["`*1FD.14*<br/>types/world core`"]:::open
     1FD.15["`*1FD.15*<br/>types/world relations`"]:::blocked
     1FD.16["`*1FD.16*<br/>types/world provenance`"]:::blocked

--- a/docs/roadmaps/mvp.md
+++ b/docs/roadmaps/mvp.md
@@ -6,7 +6,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 |          | Status                  | Next Up           | Blocked           |
 | -------- | ----------------------- | ----------------- | ----------------- |
-| **FD**   | In progress             | 1FD.13            | —                 |
+| **FD**   | In progress             | 1FD.17, 1FD.19, 1FD.20, 1FD.28, 1FD.31 | — |
 | **GN**   | Not started             | 2GN.1, 2GN.2, 2GN.17, 2GN.22 | —      |
 | **WS**   | Not started             | —                 | 2GN.56            |
 | **UI**   | Not started             | —                 | 3WS.15            |
@@ -50,31 +50,24 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 **Type system**
 
-- [ ] 1FD.13. `src/lib/types/decoration.ts` — `DecorativeLayer`, `DecorativeTechnique`, surface/applied/textile element types
-- [ ] 1FD.14. `src/lib/types/world.ts` — `WorldSeed`, `WorldChronology`, `CultureTimeline`, `CulturePhase`, `PhaseCharacteristics`, `Culture`, `CulturalProfile`, `CraftInvestmentProfile`, `MotifSet`
-- [ ] 1FD.15. `src/lib/types/world.ts` — `CultureRelationship`, `RelationshipPhase`, `RelationshipDynamics`, `MaterialFlow`
-- [ ] 1FD.16. `src/lib/types/world.ts` — `Provenance`, `SiteType`, `PreservationState`, `DepositionType`, `GeologicalContext`, `RegionalAvailability`, `AvailabilityLevel` (site-composition/excavation types live here; doc 08's `types/excavation.ts` is folded in)
 - [ ] 1FD.17. `src/lib/types/world.ts` — `DatingFramework`, `LayerDating`, `DatingMethod`
-- [ ] 1FD.18. `src/lib/types/interpretation.ts` — `InterpretiveModel`, `Observation`, `Inference`, `EvidenceLink`, `InferenceScope`, `Hypothesis`, `Confidence`
-- [ ] 1FD.19. `src/lib/types/interpretation.ts` — `CulturalClaim`, `ArtefactClaim`, `ChronoClaim`, `AgentAssessment`, `MethodologicalProfile` (strain lives in `HypothesisStrain`, 1FD.25 — the name `StrainScore` is retired)
+- [ ] 1FD.19. `src/lib/types/interpretation.ts` — `CulturalClaim`, `ArtefactClaim`, `ChronoClaim`, `AgentAssessment`, `MethodologicalProfile` (strain lives in `HypothesisStrain`, 1FD.25 — the name `StrainScore` is retired; resolves the five same-file `TODO(1FD.19)` stand-ins in `interpretation.ts`)
 - [ ] 1FD.20. `src/lib/types/lens.ts` — `LensStrength`, `ObservationSalience`, `ClassificationSuggestion`, `CrossReference`, `DescriptionFrame`, `OmissionCheck`, `LensState`
 - [ ] 1FD.21. `src/lib/types/documents.ts` — `DocumentNode`, `DocumentLineage`, `DerivationType`, `DerivationEvent`, `DocumentScope`, `Audience`, `PublicationRegister`, `DocumentPerception` (simplified MVP shape per doc 10 §11: `audienceReach`, `takeawayDivergence`, `citationCount`)
 - [ ] 1FD.22. `src/lib/types/documents.ts` — `DisseminationState`, `DisseminationEvent`, `DisseminationDetails`, `PeerReviewState`, `Retraction`, `TaintedLineage`
 - [ ] 1FD.23. `src/lib/types/venues.ts` — `VenueDefinition`, `ContainerModel`, `TemporalMode`, `SubmissionWindow`, `EditorialProcess`, `AudienceEncounter`, `VenueScope`, `VenueClassification`
 - [ ] 1FD.24. `src/lib/types/contradiction.ts` — `Contradiction` union, `MaterialContradiction`, `TemporalContradiction`, `CulturalContradiction`, `StructuralContradiction`, `ProvenanceContradiction`, `CorpusContradiction`, `RarityContradiction`, `MaterialProvenanceContradiction` (all eight members per doc 06 §4.2; `CulturalContradiction.agentClaim` references a claimId at MVP — doc 06's profileId applies once cultural-profile documents land post-MVP)
-- [ ] 1FD.25. `src/lib/types/contradiction.ts` — `ContradictionSeverity`, `ContradictionQueue`, `QueuedContradiction`, `DiegeticSurface`, `Resolution`, `HypothesisStrain`
-- [ ] 1FD.26. `src/lib/types/career.ts` — `Reputation`, `ReputationModifier`, `ReputationGate`, `CareerState`, `AcademicRole`, `CareerActivity`, `ActivityType`
+- [ ] 1FD.25. `src/lib/types/contradiction.ts` — `ContradictionSeverity`, `ContradictionQueue`, `QueuedContradiction`, `DiegeticSurface`, `Resolution`, `HypothesisStrain` (resolves the two cross-file `TODO(1FD.25)` stand-ins in `interpretation.ts`)
 - [ ] 1FD.27. `src/lib/types/career.ts` — `RoleRequirement`, `DisseminationCareerEffect`, `PeerReviewCareerEvent`, `ReviewerFeedback`
 - [ ] 1FD.28. `src/lib/types/term.ts` — `TermType`, `AcademicYear`, `TermState`, `BackgroundDrain`, `CompletedAction` (doc 08 §3.6 places both in term.ts), constants (`WEEKS_PER_TERM`, `TERMS_PER_YEAR`), helpers (`termStartWeek`, `weekInTerm`, `termIndexFromWeek`, `yearFromTerm`)
 - [ ] 1FD.29. `src/lib/types/scholars.ts` — `MinimalScholar`, `NPCScholarSeed`, `SimulatedExcavation`
 - [ ] 1FD.30. `src/lib/types/corpus.ts` — `ProfessionalCorpus`, `FrequencyRecord`, `ContextFrequency`, `ConsensusStatement`, `Debate`, `DebatePosition`, `CoverageBudget`
 - [ ] 1FD.31. `src/lib/types/description.ts` — `DescriptionTemplate`, `DescriptionVariant`, `ArtefactPresentation`, `PresentedObservation`, `TagSuggestion`, `ProvenancePresentation`, `DescriptionRegister` (`'observational' | 'interpretive' | 'technical'` per doc 04 §3.4; the five-value `ObservationRegister` + `RegisterAccess` acquisition model from doc 05 §12 is post-MVP)
-- [ ] 1FD.32. `src/lib/types/visibility.ts` — `PropertyVisibility` enum (`observable`, `inferable`, `occluded`, `engine-internal`), visibility annotation helpers
 - [ ] 1FD.33. `src/lib/types/save.ts` — `SaveFile`, `SerialisedWorldState`, `SerialisedInterpretiveModel`, `SerialisedTermState`, `CURRENT_SAVE_VERSION`
 
 **Test infrastructure**
 
-- [ ] 1FD.35. Create test fixture helpers — mock culture, mock world seed, mock artefact factories (partially done: `tests/fixtures/world.ts` has `mockWorldSeed`; mock culture blocked on 1FD.14/1FD.16; mock artefact unblocked — `NormalisedArtefact`/`ClassifiedArtefact` (1FD.11), `ArrangementPattern`/`AttachmentType` (1FD.10) and `MaterialTag` (1FD.12) now exist)
+- [ ] 1FD.35. Create test fixture helpers — mock culture, mock world seed, mock artefact factories (partially done: `tests/fixtures/world.ts` has `mockWorldSeed`; mock culture unblocked — `Culture`/`CulturalProfile` (1FD.14), `SiteType`/`DepositionType` (1FD.16) and `MaterialTag` (1FD.12) now exist; mock artefact unblocked — `NormalisedArtefact`/`ClassifiedArtefact` (1FD.11), `ArrangementPattern`/`AttachmentType` (1FD.10) and `MaterialTag` (1FD.12) now exist)
 
 **Project Explorer shell**
 
@@ -106,7 +99,14 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 - [x] 1FD.12. `src/lib/types/tags.ts` — `FunctionTag`, `ContextTag`, `MaterialTag`, `ClassificationRule`, `ClaimMagnitude` (built ahead of 1FD.10 so `grammar.ts` could import the real `MaterialTag` rather than a placeholder; `ClassificationRule.condition` typed against a local `ExtractedFeatures` stand-in until 1FD.11 landed, now imports the real type from `artefact.ts`)
 - [x] 1FD.10. `src/lib/types/grammar.ts` — `GrammarRule`, `GrammarOption`, `ArrangementPattern`, `AccumulationConstraints`, `AttachmentType` (imports `MaterialTag` from 1FD.12; `GrammarOption.expandsTo` and `.phaseModifiers` are provisional shapes, JSDoc-marked, pending 2GN.3/2GN.5)
-- [x] 1FD.11. `src/lib/types/artefact.ts` — `NormalisedArtefact`, `NormalisedComponent`, `Attachment`, `ObjectDimensions`, `Portability`, `InspectionDepth`, `ClassifiedArtefact`, `ExtractedFeatures`, `MaterialAssignment`, `MaterialDefinition`, `MaterialProvenance` (doc 05 §5.2, §6.1, §7, §9; `MaterialDefinition` has no doc 05 field shape, adopted the `{id, displayName, tags}` shape from `docs/dev/implementation/m1-artefact-generation.md` — doc 05 §15's richer geological/cultural fields deferred until `GeologicalContext`/`CulturalProfile` exist; `ClassifiedArtefact.decorativeLayers`/`.provenance` reference private `TODO(1FD.13)`/`TODO(1FD.16)` opaque `unknown` placeholders for `DecorativeLayer`/`Provenance`, owned by those tasks)
+- [x] 1FD.11. `src/lib/types/artefact.ts` — `NormalisedArtefact`, `NormalisedComponent`, `Attachment`, `ObjectDimensions`, `Portability`, `InspectionDepth`, `ClassifiedArtefact`, `ExtractedFeatures`, `MaterialAssignment`, `MaterialDefinition`, `MaterialProvenance` (doc 05 §5.2, §6.1, §7, §9; `MaterialDefinition` has no doc 05 field shape, adopted the `{id, displayName, tags}` shape from `docs/dev/implementation/m1-artefact-generation.md` — doc 05 §15's richer geological/cultural fields deferred until `GeologicalContext`/`CulturalProfile` exist; `ClassifiedArtefact.decorativeLayers`/`.provenance` now import the real `DecorativeLayer`/`Provenance` from `decoration.ts`/`world.ts`, both landed with 1FD.13/1FD.16)
+- [x] 1FD.13. `src/lib/types/decoration.ts` — `DecorativeTechnique`, `DecorativeLayer` (doc 05 §8.2–§8.3; `DecorativeTechnique` is a flat 16-member union, not a discriminated union with per-technique params, since `DecorativeLayer` only carries generic `motifRef?`/`material?` slots; material-prerequisite rules are engine/data-layer concerns, not typed here — see roadmap 2GN.28/2GN.30; resolves the `TODO(1FD.13)` stand-in in `artefact.ts`)
+- [x] 1FD.14. `src/lib/types/world.ts` — `WorldSeed`, `PhaseCharacteristics`, `CulturePhase`, `CultureTimeline`, `CulturalProfile`, `Culture`, `CraftInvestmentProfile`, `MotifSet`, `MotifDefinition`, `WorldChronology` (doc 05 §2, §3.1–§3.3; `MotifSet`/`MotifDefinition` are invented, provisional, not doc-specified — minimal shape so `DecorativeLayer.motifRef` can reference one by id; `CulturalProfile`'s JSDoc flags the unrelated same-named type in doc 06 §3.3; built together with 1FD.15/1FD.16 in the same file since `CraftInvestmentProfile` and `WorldChronology` reference their types directly)
+- [x] 1FD.15. `src/lib/types/world.ts` — `MaterialFlow`, `RelationshipDynamics`, `RelationshipPhase`, `CultureRelationship` (doc 05 §3.4, fully specified verbatim; built alongside 1FD.14/1FD.16)
+- [x] 1FD.16. `src/lib/types/world.ts` — `SiteType`, `PreservationState`, `DepositionType`, `Provenance`, `AvailabilityLevel`, `RegionalAvailability`, `GeologicalContext` (doc 05 §3.5–§3.6, fully specified verbatim; `Provenance`'s JSDoc distinguishes it from `MaterialProvenance` in `artefact.ts`; resolves the `TODO(1FD.16)` stand-in in `artefact.ts`; built alongside 1FD.14/1FD.15)
+- [x] 1FD.18. `src/lib/types/interpretation.ts` — `Confidence`, `Observation`, `EvidenceLink`, `InferenceScope`, `Inference`, `Hypothesis`, `InterpretiveModel` (doc 06 §2.1–§2.3, doc 08 §3.2; `InterpretiveModel` uses the doc 08 §3.2 "claims" shape rather than doc 06 §6's "knowledge layers" shape — the two docs conflict, and doc 08's version matches this roadmap's own field ownership (1FD.19, 1FD.25) and the concrete store-construction code in doc 08 §3.4; `Observation.observationRegister` is typed as the inline MVP three-value union pending `DescriptionRegister` from 1FD.20/1FD.31; `InterpretiveModel`'s five 1FD.19-owned fields and two 1FD.25-owned fields are private `unknown` placeholders)
+- [x] 1FD.26. `src/lib/types/career.ts` — `Reputation`, `ReputationModifier`, `ReputationGate`, `CareerState`, `AcademicRole`, `CareerActivity`, `ActivityType` (doc 07 §2, §2.2, §4.0–§4.1, fully specified verbatim and self-contained; `CareerActivity.outcomes: ActivityOutcome[]` needed an invented, provisional `ActivityOutcome` shape — doc 07 names it only as a comment, "Possible results", with no roadmap task owning it)
+- [x] 1FD.32. `src/lib/types/visibility.ts` — `PropertyVisibility` (string-literal union, not a TS `enum`, per the convention already committed in `artefact.ts`'s module JSDoc), `PROPERTY_VISIBILITY_VALUES`, `isPropertyVisibility` (doc 11 §2.7 authoritative; helpers kept minimal since there's no consumer yet — `lens.ts`, 1FD.20, is the first)
 
 **Test infrastructure**
 
@@ -679,26 +679,26 @@ graph TD
     1FD.10["`*1FD.10*<br/>types/grammar.ts`"]:::done
     1FD.11["`*1FD.11*<br/>types/artefact.ts`"]:::done
     1FD.12["`*1FD.12*<br/>types/tags.ts`"]:::done
-    1FD.13["`*1FD.13*<br/>types/decoration.ts`"]:::open
-    1FD.14["`*1FD.14*<br/>types/world core`"]:::open
-    1FD.15["`*1FD.15*<br/>types/world relations`"]:::blocked
-    1FD.16["`*1FD.16*<br/>types/world provenance`"]:::blocked
-    1FD.17["`*1FD.17*<br/>types/world dating`"]:::blocked
-    1FD.18["`*1FD.18*<br/>types/interpretation core`"]:::blocked
-    1FD.19["`*1FD.19*<br/>types/interpretation claims`"]:::blocked
-    1FD.20["`*1FD.20*<br/>types/lens.ts`"]:::blocked
+    1FD.13["`*1FD.13*<br/>types/decoration.ts`"]:::done
+    1FD.14["`*1FD.14*<br/>types/world core`"]:::done
+    1FD.15["`*1FD.15*<br/>types/world relations`"]:::done
+    1FD.16["`*1FD.16*<br/>types/world provenance`"]:::done
+    1FD.17["`*1FD.17*<br/>types/world dating`"]:::open
+    1FD.18["`*1FD.18*<br/>types/interpretation core`"]:::done
+    1FD.19["`*1FD.19*<br/>types/interpretation claims`"]:::open
+    1FD.20["`*1FD.20*<br/>types/lens.ts`"]:::open
     1FD.21["`*1FD.21*<br/>types/documents core`"]:::blocked
     1FD.22["`*1FD.22*<br/>types/documents dissem`"]:::blocked
     1FD.23["`*1FD.23*<br/>types/venues.ts`"]:::blocked
     1FD.24["`*1FD.24*<br/>types/contradiction core`"]:::blocked
     1FD.25["`*1FD.25*<br/>types/contradiction queue`"]:::blocked
-    1FD.26["`*1FD.26*<br/>types/career core`"]:::open
+    1FD.26["`*1FD.26*<br/>types/career core`"]:::done
     1FD.27["`*1FD.27*<br/>types/career drains`"]:::blocked
-    1FD.28["`*1FD.28*<br/>types/term.ts`"]:::blocked
+    1FD.28["`*1FD.28*<br/>types/term.ts`"]:::open
     1FD.29["`*1FD.29*<br/>types/scholars.ts`"]:::blocked
     1FD.30["`*1FD.30*<br/>types/corpus.ts`"]:::blocked
-    1FD.31["`*1FD.31*<br/>types/description.ts`"]:::blocked
-    1FD.32["`*1FD.32*<br/>types/visibility.ts`"]:::blocked
+    1FD.31["`*1FD.31*<br/>types/description.ts`"]:::open
+    1FD.32["`*1FD.32*<br/>types/visibility.ts`"]:::done
     1FD.33["`*1FD.33*<br/>types/save.ts`"]:::blocked
     1FD.34["`*1FD.34*<br/>Configure deno test`"]:::done
     1FD.35["`*1FD.35*<br/>Test fixture helpers (partial)`"]:::open

--- a/src/lib/types/artefact.ts
+++ b/src/lib/types/artefact.ts
@@ -1,0 +1,337 @@
+/**
+ * Artefact type definitions for the generation pipeline's structural, material and classification
+ * stages (doc 05 §5.2, §6.1, §7, §9). This module is data shapes only — no behaviour.
+ *
+ * The pipeline flows: the bottom-up grammar (doc 05 §5) produces a tree; normalisation (§6.1)
+ * flattens it into a `NormalisedArtefact`; material assignment (§7) and the decorative grammar
+ * (§8) enrich it; unified feature extraction and tag classification (§9) fold everything into a
+ * `ClassifiedArtefact`. Runtime behaviour for those stages lives under `engine/` (roadmap 2GN.*);
+ * e.g. `deriveInspectionDepth(dimensions)` (doc 05 §5.2) maps physical size to `InspectionDepth`
+ * (maxExtent <= 30 → 'full', <= 150 → 'detailed', else 'observational') and belongs to the
+ * normalisation engine, not this file.
+ *
+ * Visibility (doc 05 §1.1) is expressed in prose JSDoc per field for now; roadmap 1FD.32 will add
+ * a `PropertyVisibility` enum (`observable` | `inferable` | `occluded` | `engine-internal`) that
+ * these annotations will migrate onto.
+ */
+
+import type { ContextTag, FunctionTag, MaterialTag } from './tags.ts';
+import type { ArrangementPattern, AttachmentType } from './grammar.ts';
+
+/**
+ * TODO(1FD.13): opaque placeholder for `DecorativeLayer`, owned by `src/lib/types/decoration.ts`
+ * (doc 05 §8.3). Nothing in this file dereferences its fields, so an opaque `unknown` typechecks
+ * everywhere it is used (`ClassifiedArtefact.decorativeLayers`) while avoiding a duplicate
+ * definition that would conflict when 1FD.13 lands. Swap for
+ * `import type { DecorativeLayer } from './decoration.ts'` and delete this line then.
+ */
+type DecorativeLayer = unknown;
+
+/**
+ * TODO(1FD.16): opaque placeholder for `Provenance`, owned by `src/lib/types/world.ts` (doc 05
+ * §3.5). Used only as the type of `ClassifiedArtefact.provenance`; nothing here reads its fields.
+ * Swap for `import type { Provenance } from './world.ts'` and delete this line once 1FD.16 lands.
+ */
+type Provenance = unknown;
+
+/**
+ * Where an object sits on the single portability axis (doc 05 §5.2) — the one unambiguous
+ * criterion dividing portable artefacts (MVP scope) from non-portable features (deferred). A
+ * `team-lift` object is analytically different from a `pocketable` one — harder to move, less
+ * likely to have travelled far — but runs through the same grammar, inspection and classification
+ * pipeline. Visibility: observable (physical structure is directly perceptible).
+ */
+export type Portability =
+	| 'pocketable' // One hand, negligible effort (ring, coin, small blade)
+	| 'one-hand' // Carried in one hand (dagger, cup, brooch)
+	| 'two-hand' // Requires both hands (sword, large pot)
+	| 'team-lift' // Requires 2–4 people (bronze cauldron, stone slab)
+	| 'major-effort'; // Significant labour but IS portable (sarcophagus lid, monumental vessel)
+
+/**
+ * How closely a player can examine an artefact, derived from its physical dimensions by
+ * `deriveInspectionDepth` (doc 05 §5.2, engine code — roadmap 2GN.*): 'full' = hold and examine
+ * closely, 'detailed' = examine but not manipulate freely, 'observational' = observe in situ only.
+ * Visibility: observable.
+ */
+export type InspectionDepth =
+	| 'full'
+	| 'detailed'
+	| 'observational';
+
+/**
+ * The overall physical size and heft of an artefact (doc 05 §6.1), feeding both `Portability` and
+ * the `deriveInspectionDepth` calculation. Visibility: observable.
+ */
+export interface ObjectDimensions {
+	/** Longest axis, in centimetres. */
+	primaryExtent: number;
+
+	/** Perpendicular extent, in centimetres. */
+	secondaryExtent: number;
+
+	/** Coarse mass band; artefacts are not weighed to the gram. */
+	mass:
+		| 'negligible'
+		| 'light'
+		| 'moderate'
+		| 'heavy'
+		| 'very-heavy';
+}
+
+/**
+ * One physical join between two components (doc 05 §6.1) — the flattened form of the grammar's
+ * `<attachment>` production (doc 05 §5.3). Purely structural; carries no functional meaning.
+ * Visibility: observable.
+ */
+export interface Attachment {
+	/** Id of the component the join originates from. */
+	fromComponentId: string;
+
+	/** Id of the component the join connects to. */
+	toComponentId: string;
+
+	/** The physical join type (doc 05 §5.3). */
+	type: AttachmentType;
+}
+
+/**
+ * One flattened component of a normalised artefact (doc 05 §6.1) — a geometric primitive with its
+ * properties, the material tags it can physically be made from, and its place along the object's
+ * primary axis. Visibility: observable.
+ */
+export interface NormalisedComponent {
+	/** Stable id, referenced by `Attachment`, `MaterialAssignment` and `DecorativeLayer`. */
+	id: string;
+
+	/** The grammar primitive this came from (e.g. 'elongated', 'cylindrical'; doc 05 §5.3). */
+	primitiveType: string;
+
+	/** Primitive parameters (e.g. length, crossSection), keyed by name (doc 05 §5.3). */
+	properties: Map<string, string | number>;
+
+	/**
+	 * Material tags this component can physically be made from, derived from primitive +
+	 * properties by a compatibility table (doc 05 §6.1) — a physical constraint, not a grammar
+	 * choice.
+	 */
+	allowedMaterialTags: MaterialTag[];
+
+	/** Ordering along the object's primary axis. */
+	position: number;
+
+	/**
+	 * Present when this component is one of a repeated set laid out as an arrangement group (doc
+	 * 05 §5.5). Kept inline (see `ArrangementPattern` in grammar.ts). Absent for one-off
+	 * components.
+	 */
+	arrangementGroup?: {
+		/** The layout pattern of the group (e.g. symmetric, radial; doc 05 §5.5). */
+		pattern: ArrangementPattern;
+
+		/** This component's index within the arrangement. */
+		index: number;
+
+		/** Total number of components in the arrangement group. */
+		totalInGroup: number;
+	};
+}
+
+/**
+ * A named material the pipeline can assign to a component (doc 05 §7). `assignMaterial` (roadmap
+ * 2GN.*) filters candidates by `tags` against a component's `allowedMaterialTags`, then weights
+ * the survivors. `MaterialAssignment.materialId` references `id`; `displayName` is the observable
+ * material identity (doc 05 §1.1). Visibility: observable (material identity).
+ *
+ * Doc 05 §15 envisions a richer definition carrying geological availability and cultural
+ * affinities; those fields are deferred until `GeologicalContext` (roadmap 1FD.16) and
+ * `CulturalProfile` (roadmap 1FD.14) exist to type them.
+ */
+export interface MaterialDefinition {
+	/** Stable id, referenced by `MaterialAssignment.materialId`. */
+	id: string;
+
+	/** Human-readable material name shown to the player (e.g. 'bronze', 'obsidian'). */
+	displayName: string;
+
+	/** What this material is, for compatibility filtering against components (doc 05 §7). */
+	tags: MaterialTag[];
+}
+
+/**
+ * Where a material assignment's raw material likely originated (doc 05 §7.1). Hidden from the
+ * player — they see the material and must infer its provenance. A copper artefact from a culture
+ * with no local copper is a puzzle: trade, migration, or misattribution? Visibility: inferable
+ * (geological provenance), per doc 05 §1.1.
+ */
+export interface MaterialProvenance {
+	/** How the material reached this artefact. */
+	source:
+		| 'local'
+		| 'regional'
+		| 'trade'
+		| 'unknown';
+
+	/** Best guess at the origin region, when one can be attributed. */
+	likelyOriginRegion?: string;
+
+	/** If a trade material, which trade relationship enabled it (doc 05 §7.1). */
+	tradePathId?: string;
+}
+
+/**
+ * A per-component material assignment with its provenance (doc 05 §7.1). One entry per component
+ * that has been assigned a material.
+ */
+export interface MaterialAssignment {
+	/** Id of the `NormalisedComponent` this assignment applies to. */
+	componentId: string;
+
+	/** Id of the assigned `MaterialDefinition`. */
+	materialId: string;
+
+	/** Where the raw material likely came from (doc 05 §7.1). Occluded from the player. */
+	provenance: MaterialProvenance;
+}
+
+/**
+ * The flattened, standardised artefact structure produced by normalisation (doc 05 §6.1) — the
+ * grammar's node tree collapsed into ordered components, their attachments, and the whole object's
+ * dimensions and portability. The base shape that material, decorative and classification stages
+ * extend. Visibility: observable.
+ */
+export interface NormalisedArtefact {
+	/** Stable artefact id. */
+	id: string;
+
+	/** The flattened components, ordered by `position` (doc 05 §6.1). */
+	components: NormalisedComponent[];
+
+	/** The physical joins between components (doc 05 §6.1). */
+	attachments: Attachment[];
+
+	/** Overall size and heft (doc 05 §6.1). */
+	dimensions: ObjectDimensions;
+
+	/** Portability band, derived from dimensions and structure (doc 05 §5.2). */
+	portability: Portability;
+
+	/** How closely the artefact can be examined, derived from dimensions (doc 05 §5.2). */
+	inspectionDepth: InspectionDepth;
+}
+
+/**
+ * The single unified feature set extracted once across a complete artefact — structure, materials
+ * and decorative layers together (doc 05 §9.1). Consumed by classification rules (doc 05 §9.2,
+ * `ClassificationRule` in tags.ts) to score function and context tags. Every feature is traceable
+ * to its source component or decorative layer for the lens and contradiction systems, but the
+ * extraction itself is unified. Physical features are observable; their classificatory weight is
+ * occluded (doc 05 §1.1, §9.1).
+ */
+export interface ExtractedFeatures {
+	// Structural features
+	/** Whether any component has a cutting edge. */
+	hasEdge: boolean;
+
+	/** How many distinct edges are present. */
+	edgeCount: number;
+
+	/** Whether any component comes to a point. */
+	hasPoint: boolean;
+
+	/** Whether any component presents a striking/impact surface. */
+	hasImpactSurface: boolean;
+
+	/** Whether the artefact encloses a volume (a container). */
+	hasContainer: boolean;
+
+	/** How open that container is, 0 (sealed) to 1 (fully open). */
+	containerOpenness: number;
+
+	/** Whether the artefact has a fastening mechanism (clasp, pin, hinge). */
+	hasFasteningMechanism: boolean;
+
+	/** Coarse length band of the primary axis. */
+	primaryAxisLength:
+		| 'short'
+		| 'medium'
+		| 'long';
+
+	/** Whether the artefact reads as something worn on the body. */
+	isWearable: boolean;
+
+	/** Number of components. */
+	partCount: number;
+
+	/** How varied the attachment types are — a diversity measure over `AttachmentType`. */
+	attachmentDiversity: number;
+
+	// Decorative features
+	/** Total number of decorative layers across the artefact. */
+	decorativeLayerCount: number;
+
+	/** Whether any decorative layer carries a motif. */
+	motifPresent: boolean;
+
+	/** Which cultures' motif vocabularies are represented (doc 05 §8.5). */
+	motifCulturalOrigins: string[];
+
+	/** Layering depth × technique variety (doc 05 §9.1). */
+	techniqueComplexity: number;
+
+	/** Whether precious materials appear in the decoration. */
+	preciousMaterialsInDecoration: boolean;
+
+	// Combined
+	/** Edge + point + impact + container (doc 05 §9.1). */
+	functionalComplexity: number;
+
+	/** Layer count + technique variety + motif density (doc 05 §9.1). */
+	decorativeComplexity: number;
+
+	/** Structural + decorative complexity combined (doc 05 §9.1). */
+	overallComplexity: number;
+
+	// Dimensional
+	/** Portability band carried through from the normalised artefact (doc 05 §5.2). */
+	portability: Portability;
+
+	/** Inspection depth carried through from the normalised artefact (doc 05 §5.2). */
+	inspectionDepth: InspectionDepth;
+}
+
+/**
+ * The fully classified artefact (doc 05 §9.3) — a `NormalisedArtefact` enriched with its assigned
+ * materials, decorative layers, extracted features, ground-truth tags, a neutral physical label,
+ * and provenance. The terminal product of the generation pipeline.
+ */
+export interface ClassifiedArtefact extends NormalisedArtefact {
+	/** Per-component material assignments (doc 05 §7). */
+	materials: MaterialAssignment[];
+
+	/** The decorative layers applied to the artefact (doc 05 §8.3). Owned by roadmap 1FD.13. */
+	decorativeLayers: DecorativeLayer[];
+
+	/** The unified extracted feature set (doc 05 §9.1). */
+	features: ExtractedFeatures;
+
+	/**
+	 * The true function/context tag scores (doc 05 §9.2–§9.3). Visibility: occluded — never
+	 * exposed to the player or any agent's interpretive model; they exist solely for the engine to
+	 * evaluate claims against reality.
+	 */
+	groundTruthTags: Map<FunctionTag | ContextTag, number>;
+
+	/**
+	 * A neutral, observable physical description (doc 05 §9.3) — e.g. 'short bronze elongated
+	 * form with engraved disc-form attachment', never an interpretive name like 'ceremonial
+	 * dagger'. Interpretive naming is the player's job. Visibility: observable.
+	 */
+	physicalLabel: string;
+
+	/** Chronological, cultural and depositional provenance (doc 05 §3.5). Owned by roadmap 1FD.16. */
+	provenance: Provenance;
+
+	/** Per-component material provenance (doc 05 §7.1). Occluded from the player. */
+	materialProvenance: MaterialProvenance[];
+}

--- a/src/lib/types/artefact.ts
+++ b/src/lib/types/artefact.ts
@@ -17,22 +17,8 @@
 
 import type { ContextTag, FunctionTag, MaterialTag } from './tags.ts';
 import type { ArrangementPattern, AttachmentType } from './grammar.ts';
-
-/**
- * TODO(1FD.13): opaque placeholder for `DecorativeLayer`, owned by `src/lib/types/decoration.ts`
- * (doc 05 §8.3). Nothing in this file dereferences its fields, so an opaque `unknown` typechecks
- * everywhere it is used (`ClassifiedArtefact.decorativeLayers`) while avoiding a duplicate
- * definition that would conflict when 1FD.13 lands. Swap for
- * `import type { DecorativeLayer } from './decoration.ts'` and delete this line then.
- */
-type DecorativeLayer = unknown;
-
-/**
- * TODO(1FD.16): opaque placeholder for `Provenance`, owned by `src/lib/types/world.ts` (doc 05
- * §3.5). Used only as the type of `ClassifiedArtefact.provenance`; nothing here reads its fields.
- * Swap for `import type { Provenance } from './world.ts'` and delete this line once 1FD.16 lands.
- */
-type Provenance = unknown;
+import type { DecorativeLayer } from './decoration.ts';
+import type { Provenance } from './world.ts';
 
 /**
  * Where an object sits on the single portability axis (doc 05 §5.2) — the one unambiguous
@@ -144,8 +130,9 @@ export interface NormalisedComponent {
  * material identity (doc 05 §1.1). Visibility: observable (material identity).
  *
  * Doc 05 §15 envisions a richer definition carrying geological availability and cultural
- * affinities; those fields are deferred until `GeologicalContext` (roadmap 1FD.16) and
- * `CulturalProfile` (roadmap 1FD.14) exist to type them.
+ * affinities. `GeologicalContext` (world.ts, roadmap 1FD.16) and `CulturalProfile` (world.ts,
+ * roadmap 1FD.14) now exist to type those fields, but adding them here is a deliberate follow-up,
+ * not part of building `world.ts` itself — this interface is unchanged for now.
  */
 export interface MaterialDefinition {
 	/** Stable id, referenced by `MaterialAssignment.materialId`. */
@@ -309,7 +296,7 @@ export interface ClassifiedArtefact extends NormalisedArtefact {
 	/** Per-component material assignments (doc 05 §7). */
 	materials: MaterialAssignment[];
 
-	/** The decorative layers applied to the artefact (doc 05 §8.3). Owned by roadmap 1FD.13. */
+	/** The decorative layers applied to the artefact (doc 05 §8.3). */
 	decorativeLayers: DecorativeLayer[];
 
 	/** The unified extracted feature set (doc 05 §9.1). */
@@ -329,7 +316,7 @@ export interface ClassifiedArtefact extends NormalisedArtefact {
 	 */
 	physicalLabel: string;
 
-	/** Chronological, cultural and depositional provenance (doc 05 §3.5). Owned by roadmap 1FD.16. */
+	/** Chronological, cultural and depositional provenance (doc 05 §3.5). */
 	provenance: Provenance;
 
 	/** Per-component material provenance (doc 05 §7.1). Occluded from the player. */

--- a/src/lib/types/career.ts
+++ b/src/lib/types/career.ts
@@ -165,7 +165,7 @@ export interface CareerActivity {
 	};
 
 	/** Activity types that cannot run concurrently with this one (doc 07 §4.1). */
-	exclusive?: string[];
+	exclusive?: ActivityType[];
 
 	/** Possible results of completing this activity (doc 07 §4.1). */
 	outcomes: ActivityOutcome[];

--- a/src/lib/types/career.ts
+++ b/src/lib/types/career.ts
@@ -1,0 +1,204 @@
+/**
+ * Career and reputation type definitions (doc 07 §2, §2.2, §4.0–§4.1).
+ *
+ * Reputation is multidimensional, not a single score: a player can be respected for rigour while
+ * dismissed for originality. Reputation gates certain activities and its dimensions shift from
+ * career events (doc 07 §2.1) — publishing, retracting, resolving or ignoring contradictions, and
+ * so on. `CareerState` and `CareerActivity` describe the concurrent-undertakings model (doc 07
+ * §4.1): a term's activities compete for a shared time and energy budget rather than a single
+ * "pick one action" slot. Time and energy accounting itself (terms, weeks, background drains) is
+ * owned by `src/lib/types/term.ts` (roadmap 1FD.28); this file references those concepts only via
+ * plain numbers, taking no dependency on it. This module is data shapes only, no behaviour.
+ */
+
+/**
+ * A player or NPC scholar's standing across five independent dimensions (doc 07 §2) plus an
+ * overall composite. Not a single number — a player can be respected in one dimension and
+ * dismissed in another, and reputation gates (`ReputationGate`) check individual dimensions rather
+ * than the composite alone.
+ */
+export interface Reputation {
+	/** Weighted composite across all dimensions, 0–1 (doc 07 §2). */
+	overall: number;
+
+	/** The five independent reputation dimensions (doc 07 §2). */
+	dimensions: {
+		/** Quality of evidence chains. */
+		rigour: number;
+
+		/** Range of cultures/periods studied. */
+		breadth: number;
+
+		/** Novel claims vs echoing peers. */
+		originality: number;
+
+		/** Track record of claims surviving scrutiny. */
+		reliability: number;
+
+		/** Citations, students, public reach. */
+		influence: number;
+	};
+
+	/** Active temporary effects layered on top of the base dimensions (doc 07 §2). */
+	modifiers: ReputationModifier[];
+}
+
+/**
+ * One active effect nudging a single reputation dimension (doc 07 §2), applied by career events
+ * such as publication, retraction, or contradiction resolution (doc 07 §2.1). Modifiers either
+ * persist indefinitely or decay by a fixed amount each term.
+ */
+export interface ReputationModifier {
+	/** What caused this modifier (e.g. a document id, an event name). */
+	source: string;
+
+	/** Which dimension of `Reputation['dimensions']` this modifier affects. */
+	dimension: keyof Reputation['dimensions'];
+
+	/** The signed adjustment applied to the dimension. */
+	delta: number;
+
+	/** Permanent, or decaying by a fixed fraction of its effect each term. */
+	duration:
+		| 'permanent'
+		| { decayPerTerm: number };
+
+	/** Term index (absolute week or term counter) when this modifier was applied. */
+	appliedAt: number;
+}
+
+/**
+ * A reputation threshold gating access to a career activity or professional opportunity (doc 07
+ * §2.2) — e.g. a journal editor declining a submission until rigour improves. `failureMessage` is
+ * always diegetic: the player never sees a raw "requirement not met", only the in-world reason.
+ */
+export interface ReputationGate {
+	/** Identifier of the activity or opportunity this gate protects (doc 07 §2.2). */
+	activity: string;
+
+	/** Which dimension of `Reputation['dimensions']` must clear `threshold`. */
+	requiredDimension: keyof Reputation['dimensions'];
+
+	/** Minimum value required in `requiredDimension` (doc 07 §2.2). */
+	threshold: number;
+
+	/** Diegetic explanation shown to the player when the gate blocks them. */
+	failureMessage: string;
+}
+
+/**
+ * The player's (or an NPC scholar's) current professional standing and concurrent undertakings
+ * (doc 07 §4.0). Activities run concurrently within a term, competing for a shared time and energy
+ * budget rather than a single "pick one action" slot (doc 07 §4.1). Term and week accounting are
+ * owned by `src/lib/types/term.ts` (roadmap 1FD.28); this shape references only plain counts.
+ */
+export interface CareerState {
+	/** The current academic rank (doc 07 §4.0). */
+	currentRole: AcademicRole;
+
+	/** Activities currently available and running this term (doc 07 §4.0). */
+	activities: CareerActivity[];
+
+	/** Activities finished in prior terms, retained for history and career checks. */
+	completedActivities: CareerActivity[];
+
+	/** Whether the player holds tenure. */
+	tenure: boolean;
+
+	/** Number of field seasons the player has led excavations for (doc 07 §4.0). */
+	fieldSeasons: number;
+
+	/** Total number of students mentored to date. */
+	studentsSupervised: number;
+
+	/** Media visibility, 0–1 (doc 07 §4.0). */
+	publicProfile: number;
+
+	/** Terms remaining until sabbatical becomes available again (doc 07 §4.0). */
+	sabbaticalCooldown: number;
+
+	/** Whether the player is currently on sabbatical (doc 07 §4.0). */
+	onSabbatical: boolean;
+}
+
+/**
+ * The academic ranks a player or NPC scholar can hold (doc 07 §4.0), ordered junior to senior.
+ * Rank determines background drain profile (doc 07 §4.0 table) and gates sabbatical eligibility
+ * (Reader/Professor only).
+ */
+export type AcademicRole =
+	| 'postdoctoral-researcher'
+	| 'junior-lecturer'
+	| 'senior-lecturer'
+	| 'reader'
+	| 'professor';
+
+/**
+ * One concurrent undertaking within a term (doc 07 §4.1) — teaching, research, and administrative
+ * obligations all compete for the same time and energy budget. Multiple activities can run
+ * simultaneously; the constraint is affording the combined energy cost, not picking a single
+ * action.
+ */
+export interface CareerActivity {
+	/** Stable id for this activity instance. */
+	id: string;
+
+	/** Which kind of undertaking this is (doc 07 §4.1). */
+	type: ActivityType;
+
+	/** Whether the activity can currently be started (requirements met, not exclusive-blocked). */
+	available: boolean;
+
+	/** Reputation gates that must pass for this activity to be available (doc 07 §2.2). */
+	requirements: ReputationGate[];
+
+	/** Weeks within the term this activity consumes (doc 07 §4.1). */
+	timeCost: number;
+
+	/** Energy spent starting and sustaining the activity (doc 07 §4.1). */
+	energyCost: {
+		/** Energy spent at the start. */
+		upfront: number;
+
+		/** Ongoing drain while the activity runs. */
+		perWeek: number;
+	};
+
+	/** Activity types that cannot run concurrently with this one (doc 07 §4.1). */
+	exclusive?: string[];
+
+	/** Possible results of completing this activity (doc 07 §4.1). */
+	outcomes: ActivityOutcome[];
+}
+
+/**
+ * The seven kinds of concurrent undertaking an academic career offers (doc 07 §4.1), each with a
+ * distinct time/energy profile and a distinct effect on the wider game systems.
+ */
+export type ActivityType =
+	| 'field-season' // Lead excavation -> new artefacts
+	| 'conference-presentation' // Present findings -> reputation + peer feedback
+	| 'grant-application' // Secure funding -> unlock field season or equipment
+	| 'student-supervision' // Mentor student -> student questions (contradiction channel)
+	| 'peer-review' // Review others' work -> see alternative interpretations
+	| 'public-engagement' // Public events -> influence + popular writing
+	| 'sabbatical'; // Reduced lens + full energy + no background drains
+
+/**
+ * Provisional: doc 07 §4.1 references `ActivityOutcome` only as `CareerActivity.outcomes` with the
+ * inline comment "Possible results" and never defines its shape, nor is it owned by any roadmap
+ * task. This is an invented minimal shape, not doc-specified: a human-readable description plus an
+ * optional reputation delta and an optional follow-on unlock. Expect this to firm up once roadmap
+ * 1FD.27 (which owns the closely related `PeerReviewCareerEvent`, `ReviewerFeedback` and
+ * `DisseminationCareerEffect`) lands.
+ */
+export interface ActivityOutcome {
+	/** Human-readable description of this outcome, shown to the player. */
+	description: string;
+
+	/** Optional per-dimension reputation adjustment this outcome applies. */
+	reputationEffect?: Partial<Record<keyof Reputation['dimensions'], number>>;
+
+	/** Id of an activity this outcome unlocks, if any. */
+	unlocksActivity?: string;
+}

--- a/src/lib/types/decoration.ts
+++ b/src/lib/types/decoration.ts
@@ -1,0 +1,79 @@
+/**
+ * Decorative grammar type definitions (doc 05 §8.2–§8.3).
+ *
+ * After the physical structure exists and materials are assigned, a separate decorative grammar
+ * runs over the artefact: each structural surface becomes a potential canvas for surface
+ * treatments, applied elements and textile elements (doc 05 §8.1–§8.2). Decorative layers can
+ * themselves receive further decoration, so `DecorativeLayer` nests recursively (doc 05 §8.3) —
+ * layering depth is capped by the culture's `craftSpecialisation` and `aesthetics.decorativeEmphasis`
+ * (doc 05 §8.3), enforced by the decorative grammar's runtime expansion in
+ * `engine/generation/decoration.ts` (roadmap 2GN.33), not by this module. Decoration feeds into
+ * the same unified tag classification as structural features (doc 05 §8.1, §9) via
+ * `ExtractedFeatures` in artefact.ts. This module is data shapes only, no behaviour.
+ *
+ * Material prerequisites (the `[requires: ...]` annotations on the BNF grammar, doc 05 §8.2) are
+ * out of scope here — they are enforced by `data/decorations.ts` (roadmap 2GN.28) and the
+ * decorative grammar's expansion logic (roadmap 2GN.30), not represented as a type in this file.
+ */
+
+/**
+ * The sixteen terminals of the decorative grammar's three productions (doc 05 §8.2) — a flat
+ * union rather than a discriminated one, since `DecorativeLayer` carries only generic
+ * `motifRef?`/`material?` slots and has no field for a technique's other BNF arguments (e.g.
+ * `painting`'s pigment, `overlay`'s coverage, `studs`'/`wrapping`'s pattern). Inventing fields for
+ * those would go beyond what doc 05 §8.3 specifies. Grouped below by BNF category; the grouping
+ * is expressed only as comments, since the doc does not name the three categories as separate
+ * types.
+ */
+export type DecorativeTechnique =
+	// surface-treatment (doc 05 §8.2)
+	| 'polish'
+	| 'patina'
+	| 'roughening'
+	| 'scoring'
+	| 'engraving' // [requires: hard material]
+	| 'relief' // [requires: thick material]
+	| 'painting' // [requires: solid surface]
+	| 'glaze' // [requires: ceramic]
+	// applied-element (doc 05 §8.2)
+	| 'inlay' // [requires: engravable surface]
+	| 'overlay' // [requires: rigid surface]
+	| 'studs' // [requires: rigid or leather]
+	| 'wire-wrapping' // [requires: grippable form]
+	| 'gilding' // [requires: metal surface]
+	// textile-element (doc 05 §8.2)
+	| 'wrapping' // [requires: grippable form]
+	| 'tassels'
+	| 'beading'; // [requires: attachment point]
+
+/**
+ * One act of decorative craft applied to a component (doc 05 §8.3) — a bronze panel gets
+ * engraved; the engraved channels get silver inlay; the silver inlay gets its own chased pattern,
+ * each an entry in `sublayers`. The nesting sequence itself is meaningful: if a base layer uses
+ * one culture's motifs and a sublayer uses another's, that tells a story of contact, reworking or
+ * appropriation that the player must notice unaided (doc 05 §8.4) — nothing in this shape flags
+ * it. Visibility: observable (the decoration is physically present on the artefact), but the
+ * temporal ordering between layers and the cultural story it implies is inferable, not stated.
+ */
+export interface DecorativeLayer {
+	/** Id of the `NormalisedComponent` (artefact.ts) this layer is applied to. */
+	targetComponentId: string;
+
+	/** Which of the sixteen decorative grammar terminals this layer applies (doc 05 §8.2). */
+	technique: DecorativeTechnique;
+
+	/**
+	 * Motif drawn from the source culture's motif vocabulary, when this technique carries one (doc
+	 * 05 §8.5) — references an entry in that culture's `MotifSet.motifs` (`world.ts`, roadmap
+	 * 1FD.14). Two cultures sharing motifs via cultural exchange create genuine interpretive
+	 * ambiguity over which culture an artefact belongs to (doc 05 §8.5). Absent for techniques that
+	 * carry no motif (e.g. `polish`, `patina`).
+	 */
+	motifRef?: string;
+
+	/** The material this layer introduces, when the technique adds one (e.g. `inlay`, `gilding`). */
+	material?: string;
+
+	/** Further decoration applied on top of this layer (doc 05 §8.3). Empty when undecorated. */
+	sublayers: DecorativeLayer[];
+}

--- a/src/lib/types/interpretation.ts
+++ b/src/lib/types/interpretation.ts
@@ -1,0 +1,350 @@
+/**
+ * Interpretive model type definitions (doc 06 §2.1–§2.3, doc 08 §3.2) — core types only
+ * (roadmap 1FD.18). Observations, inferences and hypotheses form the directed graph of an agent's
+ * knowledge (doc 06 §1): raw notes on artefacts, logical connections between them, and the broader
+ * claims built from those connections. `InterpretiveModel` is the agent-generic container for all
+ * of it — the same shape the player and every NPC scholar's subjective state conforms to (doc 11
+ * §2.6, doc 08 §3.1–§3.2). This module is data shapes only, no behaviour.
+ *
+ * `CulturalClaim`, `ArtefactClaim`, `ChronoClaim`, `AgentAssessment` and `MethodologicalProfile`
+ * are specified here in doc 08 §3.2 but owned by roadmap 1FD.19 (a later task against this same
+ * file); they are opaque placeholders below until that task lands.
+ */
+
+import type { ContextTag, FunctionTag, MaterialTag } from './tags.ts';
+
+/**
+ * How strongly an agent commits to a claim (doc 06 §2.1), shared across observations, inferences
+ * and hypotheses. Runs from a hunch to a settled certainty.
+ */
+export type Confidence =
+	| 'speculative'
+	| 'tentative'
+	| 'confident'
+	| 'certain';
+
+/**
+ * A raw note attached to a specific artefact (doc 06 §2.1) — the ground floor of the knowledge
+ * graph. The player (or NPC) records what they perceive, filtered through the lens without their
+ * knowledge. Cheap to create and revise; revision history is tracked via `revisedAtTerm` and
+ * `supersededBy` so the player and the contradiction detector can see how interpretations shifted.
+ */
+export interface Observation {
+	/** Stable id, referenced by `EvidenceLink.sourceId` and `supersededBy`. */
+	id: string;
+
+	/** The artefact this observation is about. */
+	artefactId: string;
+
+	/**
+	 * Targets a specific component or component-group rather than the whole artefact, aligning
+	 * with the bottom-up component grammar (doc 05) — e.g. `'grip-system'`, `'head-system'`.
+	 * Absent when the observation is about the artefact as a whole.
+	 */
+	componentRef?: {
+		/** Which arrangement group, e.g. `'grip-system'`, `'head-system'` (doc 05). */
+		groupId?: string;
+
+		/** Which specific component within a group, e.g. a particular blade or handle component. */
+		componentId?: string;
+	};
+
+	/**
+	 * Targets a specific decorative element (doc 05 §8) rather than a structural component. Absent
+	 * when the observation is not about decoration.
+	 */
+	decorativeRef?: {
+		/** Which decorative layer the element belongs to. */
+		layerId?: string;
+
+		/** The kind of decorative element referenced (doc 05 §8). */
+		elementType?:
+			| 'motif'
+			| 'surface-treatment'
+			| 'applied-element'
+			| 'inscription';
+
+		/** Id of the specific motif, treatment or other element within the layer. */
+		elementId?: string;
+	};
+
+	/** The player's (or NPC's) note, in their own words. */
+	content: string;
+
+	/** Which artefact properties this observation references. */
+	propertyRefs: string[];
+
+	/** Player-assigned tags (doc 05 §9.2). Not mutually exclusive. */
+	tags: (FunctionTag | ContextTag)[];
+
+	/** How strongly the agent holds this observation. */
+	confidence: Confidence;
+
+	/**
+	 * Whether the agent was describing what they saw (`'observational'`) or what they think it
+	 * means (`'interpretive'`) — distinct from `observationRegister`, which tracks the framing
+	 * rather than the epistemic commitment (doc 06 §2.1). Matters for contradiction detection and
+	 * lens calibration: interpretive-mode notes carry more inferential weight.
+	 */
+	epistemicMode: 'observational' | 'interpretive';
+
+	/**
+	 * Which framing register was active when the observation was made (doc 06 §2.1). Independent
+	 * of `epistemicMode` — a note can be technical-register and observational-mode, or
+	 * technical-register and interpretive-mode.
+	 *
+	 * MVP note: this is the three-value `DescriptionRegister` from doc 04 §3.4, not the post-MVP
+	 * five-register `ObservationRegister` model from doc 05 §12 (doc 06 §2.1, doc 13). Typed
+	 * inline for now because `DescriptionRegister` doesn't exist yet.
+	 *
+	 * TODO: replace this inline union with an import of `DescriptionRegister` from `./lens.ts`
+	 * (roadmap 1FD.20) or `./description.ts` (roadmap 1FD.31), whichever lands first, once either
+	 * exists.
+	 */
+	observationRegister?:
+		| 'observational'
+		| 'interpretive'
+		| 'technical';
+
+	/** Term index when the observation was first recorded. */
+	createdAtTerm: number;
+
+	/** Term index of the most recent revision, if any. */
+	revisedAtTerm?: number;
+
+	/** Id of the observation that superseded this one, if it has been revised away. */
+	supersededBy?: string;
+}
+
+/**
+ * One link in an inference's evidence chain (doc 06 §2.2), pointing back at the observation,
+ * inference or document that supports (or undermines) the conclusion.
+ */
+export interface EvidenceLink {
+	/** What kind of node this link points to. */
+	sourceType: 'observation' | 'inference' | 'document';
+
+	/** Id of the referenced observation, inference or document. */
+	sourceId: string;
+
+	/**
+	 * The evidential relationship this link expresses. A loose string rather than a union (doc 06
+	 * §2.2); conventional values are `'supports'`, `'suggests'`, `'contradicts'` and
+	 * `'contextualises'`.
+	 */
+	role: string;
+
+	/** The agent's own explanation of why this evidence matters. */
+	note?: string;
+}
+
+/**
+ * What an inference or hypothesis is claimed to be about (doc 06 §2.2) — a discriminated union so
+ * the scope's identifying data varies with its kind.
+ */
+export type InferenceScope =
+	| { type: 'artefact'; artefactId: string }
+	| { type: 'culture'; cultureLabel: string }
+	| { type: 'period'; periodLabel: string }
+	| { type: 'material'; materialTag: MaterialTag }
+	| { type: 'cross-cultural' };
+
+/**
+ * A logical connection between observations (doc 06 §2.2) — "I noticed X in artefact A, and Y in
+ * artefact B, therefore Z." Where the agent does actual intellectual work; the `evidenceChain` is
+ * the load-bearing structure that contradictions attack link by link.
+ */
+export interface Inference {
+	/** Stable id, referenced by `Hypothesis.supportingInferences`/`contradictingInferences`. */
+	id: string;
+
+	/** What the agent concludes. */
+	conclusion: string;
+
+	/** Ordered chain of supporting (or undermining) evidence. */
+	evidenceChain: EvidenceLink[];
+
+	/** Tags this inference bears on (doc 05 §9.2). Not mutually exclusive. */
+	tags: (FunctionTag | ContextTag)[];
+
+	/** What the inference is claimed to be about. */
+	scope: InferenceScope;
+
+	/** How strongly the agent holds this inference. */
+	confidence: Confidence;
+
+	/** Term index when the inference was first drawn. */
+	createdAtTerm: number;
+
+	/** Term index of the most recent revision, if any. */
+	revisedAtTerm?: number;
+
+	/** Whether the inference still stands, is under challenge, or has been withdrawn. */
+	status: 'active' | 'challenged' | 'retracted';
+}
+
+/**
+ * A broader claim built from multiple inferences (doc 06 §2.3) — e.g. "Culture A is a maritime
+ * trading civilisation," supported by inferences about coastal finds, imported materials and
+ * boat-related artefacts. Hypotheses feed the Interpretive Lens: `lensStrength` is computed from
+ * confidence, evidence depth, publication status, and whether the agent has taught or cited them
+ * (doc 04 §4).
+ */
+export interface Hypothesis {
+	/** Stable id, referenced by `Publication.claimIds` and lens/contradiction bookkeeping. */
+	id: string;
+
+	/** Short label for the hypothesis. */
+	title: string;
+
+	/** The full claim in the agent's own words. */
+	statement: string;
+
+	/** Ids of inferences that support this hypothesis. */
+	supportingInferences: string[];
+
+	/** Ids of inferences that weaken this hypothesis. */
+	contradictingInferences: string[];
+
+	/** Tags this hypothesis bears on (doc 05 §9.2). Not mutually exclusive. */
+	tags: (FunctionTag | ContextTag)[];
+
+	/** What the hypothesis is claimed to be about. */
+	scope: InferenceScope;
+
+	/** How strongly the agent holds this hypothesis. */
+	confidence: Confidence;
+
+	/** Computed: how much this hypothesis warps perception (doc 04 §4). */
+	lensStrength: number;
+
+	/** Whether this hypothesis has been published — locked in, and much harder to retract, if so. */
+	published: boolean;
+
+	/** Id of the publication that committed this hypothesis, once published. */
+	publicationId?: string;
+
+	/** Term index when the hypothesis was first formed. */
+	createdAtTerm: number;
+
+	/** Term index of the most recent revision, if any. */
+	revisedAtTerm?: number;
+
+	/** Whether the hypothesis still stands, is under challenge, or has been withdrawn. */
+	status: 'active' | 'challenged' | 'retracted';
+}
+
+/**
+ * TODO(1FD.19): opaque placeholder for `CulturalClaim`, owned by this same file
+ * (`src/lib/types/interpretation.ts`, doc 08 §3.2) — a later task in this file's own scope, e.g.
+ * "Culture X preferred obsidian for blades." Nothing in this file dereferences its fields, so an
+ * opaque `unknown` typechecks everywhere it is used (`InterpretiveModel.culturalClaims`) while
+ * avoiding a duplicate definition that would conflict when 1FD.19 lands. Define `CulturalClaim`
+ * directly in this file and delete this placeholder then; no import will be needed.
+ */
+type CulturalClaim = unknown;
+
+/**
+ * TODO(1FD.19): opaque placeholder for `ArtefactClaim`, owned by this same file
+ * (`src/lib/types/interpretation.ts`, doc 08 §3.2) — a later task in this file's own scope, e.g.
+ * "This blade was ceremonial." Nothing in this file dereferences its fields, so an opaque
+ * `unknown` typechecks everywhere it is used (`InterpretiveModel.artefactClaims`) while avoiding a
+ * duplicate definition that would conflict when 1FD.19 lands. Define `ArtefactClaim` directly in
+ * this file and delete this placeholder then; no import will be needed.
+ */
+type ArtefactClaim = unknown;
+
+/**
+ * TODO(1FD.19): opaque placeholder for `ChronoClaim`, owned by this same file
+ * (`src/lib/types/interpretation.ts`, doc 08 §3.2) — a later task in this file's own scope, e.g.
+ * "Period Y preceded Period Z." Nothing in this file dereferences its fields, so an opaque
+ * `unknown` typechecks everywhere it is used (`InterpretiveModel.chronologicalClaims`) while
+ * avoiding a duplicate definition that would conflict when 1FD.19 lands. Define `ChronoClaim`
+ * directly in this file and delete this placeholder then; no import will be needed.
+ */
+type ChronoClaim = unknown;
+
+/**
+ * TODO(1FD.19): opaque placeholder for `AgentAssessment`, owned by this same file
+ * (`src/lib/types/interpretation.ts`, doc 08 §3.2) — a later task in this file's own scope, e.g.
+ * "Dr. Okonkwo is a reliable structuralist." Nothing in this file dereferences its fields, so an
+ * opaque `unknown` typechecks everywhere it is used (`InterpretiveModel.agentAssessments`) while
+ * avoiding a duplicate definition that would conflict when 1FD.19 lands. Define `AgentAssessment`
+ * directly in this file and delete this placeholder then; no import will be needed.
+ */
+type AgentAssessment = unknown;
+
+/**
+ * TODO(1FD.19): opaque placeholder for `MethodologicalProfile`, owned by this same file
+ * (`src/lib/types/interpretation.ts`, doc 08 §3.2) — a later task in this file's own scope,
+ * shaping how an agent weighs new evidence. Nothing in this file dereferences its fields, so an
+ * opaque `unknown` typechecks everywhere it is used (`InterpretiveModel.methodologicalWeights`)
+ * while avoiding a duplicate definition that would conflict when 1FD.19 lands. Define
+ * `MethodologicalProfile` directly in this file and delete this placeholder then; no import will
+ * be needed.
+ */
+type MethodologicalProfile = unknown;
+
+/**
+ * TODO(1FD.25): opaque placeholder for `HypothesisStrain`, owned by
+ * `src/lib/types/contradiction.ts` (doc 06 §5) — the canonical strain type; the older name
+ * `StrainScore` is retired in favour of it (roadmap 1FD.19 note). Nothing in this file
+ * dereferences its fields, so an opaque `unknown` typechecks everywhere it is used
+ * (`InterpretiveModel.strainScores`) while avoiding a duplicate definition that would conflict
+ * when 1FD.25 lands. Swap for `import type { HypothesisStrain } from './contradiction.ts'` and
+ * delete this line then.
+ */
+type HypothesisStrain = unknown;
+
+/**
+ * TODO(1FD.25): opaque placeholder for `ContradictionQueue`, owned by
+ * `src/lib/types/contradiction.ts` (doc 06 §5). Nothing in this file dereferences its fields, so
+ * an opaque `unknown` typechecks everywhere it is used (`InterpretiveModel.contradictionQueue`)
+ * while avoiding a duplicate definition that would conflict when 1FD.25 lands. Swap for
+ * `import type { ContradictionQueue } from './contradiction.ts'` and delete this line then.
+ */
+type ContradictionQueue = unknown;
+
+/**
+ * The agent-generic shape of an epistemic agent's subjective state (doc 08 §3.2) — claims about
+ * the ancient world, claims about the professional world, methodological commitments, and
+ * contradiction state, all in one container.
+ *
+ * Agent-generic per doc 11 §2.6 and doc 08 §3.1: the player and every NPC scholar share this exact
+ * interface. Engine functions (lens calculation, contradiction detection, commitment evaluation)
+ * accept an `InterpretiveModel` as a parameter and never know whose model they are processing —
+ * only the UI and store layers treat the player as special. At MVP, only the player's model is
+ * fully populated through gameplay; NPC models are generated with `culturalClaims`,
+ * `methodologicalWeights` and a subset of `artefactClaims`, while NPC `agentAssessments` and
+ * `contradictionQueue` are deferred.
+ */
+export interface InterpretiveModel {
+	/** Id of the agent (player or NPC scholar) this model belongs to. */
+	agentId: string;
+
+	/** Claims about cultures, e.g. "Culture X preferred obsidian for blades." */
+	culturalClaims: Map<string, CulturalClaim>;
+
+	/** Claims about specific artefacts, e.g. "This blade was ceremonial." */
+	artefactClaims: Map<string, ArtefactClaim>;
+
+	/** Claims about chronological ordering, e.g. "Period Y preceded Period Z." */
+	chronologicalClaims: Map<string, ChronoClaim>;
+
+	/** What this agent thinks of other agents, e.g. "Dr. Okonkwo is a reliable structuralist." */
+	agentAssessments: Map<string, AgentAssessment>;
+
+	/** This agent's methodological commitments, shaping how new evidence is weighted. */
+	methodologicalWeights: MethodologicalProfile;
+
+	/**
+	 * Strain accumulated per hypothesis under contradiction pressure (doc 06 §5). Keeps the
+	 * doc-08-sourced field name `strainScores` even though its value type is `HypothesisStrain`,
+	 * not `StrainScore` — the latter name is retired (roadmap 1FD.19 note); only the value type
+	 * changed, the field itself is unrenamed.
+	 */
+	strainScores: Map<string, HypothesisStrain>;
+
+	/** This agent's queue of unresolved contradictions awaiting attention. */
+	contradictionQueue: ContradictionQueue;
+}

--- a/src/lib/types/tags.ts
+++ b/src/lib/types/tags.ts
@@ -31,7 +31,7 @@ export type FunctionTag =
 
 /**
  * How an object was USED — its social register of use, distinct from `FunctionTag` (doc 05 §9.2).
- * Not the same axis as deposition context (`DepositionType`, doc 05 §3.3) — this describes use,
+ * Not the same axis as deposition context (`DepositionType`, doc 05 §3.5) — this describes use,
  * not how the artefact ended up in the ground.
  */
 export type ContextTag =

--- a/src/lib/types/tags.ts
+++ b/src/lib/types/tags.ts
@@ -8,6 +8,8 @@
  * sits against the professional corpus (doc 05 §4.6), not a property of the artefact itself.
  */
 
+import type { ExtractedFeatures } from './artefact.ts';
+
 /**
  * What an object was FOR — its physical/social purpose (doc 05 §9.2). Not mutually exclusive with
  * other function tags or with `ContextTag`.
@@ -58,46 +60,6 @@ export type MaterialTag =
 	| 'leather'
 	| 'precious-stone'
 	| 'precious-metal';
-
-/**
- * TODO(1FD.11): structural stand-in for the real `ExtractedFeatures` (doc 05 §9.1), which belongs
- * in `src/lib/types/artefact.ts`. That file doesn't exist yet, and `ClassificationRule.condition`
- * needs a feature shape to typecheck its predicates against — swap this for
- * `import type { ExtractedFeatures } from './artefact.ts'` once 1FD.11 lands. Field set copied
- * verbatim from doc 05 §9.1 so classification rule predicates (doc 05 §9.2) type-check against
- * real field names in the meantime. `Portability` and `InspectionDepth` (also 1FD.11) are inlined
- * as their doc-05-specified literal unions rather than imported, for the same reason.
- */
-export interface ExtractedFeatures {
-	// Structural features
-	hasEdge: boolean;
-	edgeCount: number;
-	hasPoint: boolean;
-	hasImpactSurface: boolean;
-	hasContainer: boolean;
-	containerOpenness: number;
-	hasFasteningMechanism: boolean;
-	primaryAxisLength: 'short' | 'medium' | 'long';
-	isWearable: boolean;
-	partCount: number;
-	attachmentDiversity: number;
-
-	// Decorative features
-	decorativeLayerCount: number;
-	motifPresent: boolean;
-	motifCulturalOrigins: string[];
-	techniqueComplexity: number;
-	preciousMaterialsInDecoration: boolean;
-
-	// Combined
-	functionalComplexity: number;
-	decorativeComplexity: number;
-	overallComplexity: number;
-
-	// Dimensional — TODO(1FD.11): inline placeholders for Portability/InspectionDepth literal unions.
-	portability: 'pocketable' | 'one-hand' | 'two-hand' | 'team-lift' | 'major-effort';
-	inspectionDepth: 'full' | 'detailed' | 'observational';
-}
 
 /**
  * One feature→tag scoring contribution (doc 05 §9.2). `classifyArtefact` (roadmap 2GN.20) folds

--- a/src/lib/types/visibility.ts
+++ b/src/lib/types/visibility.ts
@@ -1,0 +1,56 @@
+/**
+ * Property visibility model (doc 11 §2.7, doc 05 §1.1, doc 08 §3.1).
+ *
+ * Every property the generation pipeline produces sits at one of four visibility levels, which
+ * govern what the player can perceive, what any agent can reason about, and what exists purely for
+ * the engine's own bookkeeping. The lens (doc 04) operates exclusively on observable and inferable
+ * properties: it cannot reveal an occluded property and cannot hide an observable one, only
+ * reorder, reframe and de-emphasise. Contradictions (doc 06) fire when an agent's interpretation
+ * diverges from an occluded property.
+ *
+ * This module formalises the four levels into a type. Elsewhere in `src/lib/types/` (e.g.
+ * `artefact.ts`) the same levels are still expressed as prose JSDoc, `Visibility: observable` and
+ * similar, pending a mechanical migration onto `PropertyVisibility`. That migration is explicitly
+ * out of scope here; this file only introduces the type and its minimal helpers.
+ */
+
+/**
+ * The four levels a world-state property can sit at (doc 11 §2.7, doc 05 §1.1, doc 08 §3.1).
+ * Ground truth for what an agent's `InterpretiveModel` (roadmap 1FD.19) may ever contain and what
+ * the lens (roadmap 1FD.20) may act on.
+ */
+export type PropertyVisibility =
+	| 'observable' // Directly available on encounter, e.g. material composition, NPC published work
+	| 'inferable' // Derivable from observable properties through reasoning, e.g. cultural links
+	| 'occluded' // Definite, hidden from all agents, e.g. true culture assignments, true functions
+	| 'engine-internal'; // No in-world meaning, e.g. PRNG seeds, constraint satisfaction flags
+
+/**
+ * All `PropertyVisibility` values, in the order doc 11 §2.7 lists them. Supports iteration and
+ * runtime validation (e.g. checking a deserialised string against the vocabulary) without
+ * hand-maintaining a second copy of the four literals.
+ */
+export const PROPERTY_VISIBILITY_VALUES: readonly PropertyVisibility[] = [
+	'observable',
+	'inferable',
+	'occluded',
+	'engine-internal',
+];
+
+/**
+ * Narrows an arbitrary string to `PropertyVisibility`. The minimal runtime counterpart to the
+ * type, useful once a boundary (save data, a future authoring tool) needs to validate a value that
+ * did not arrive as `PropertyVisibility` already.
+ */
+export function isPropertyVisibility(value: string): value is PropertyVisibility {
+	return (PROPERTY_VISIBILITY_VALUES as readonly string[]).includes(value);
+}
+
+/*
+ * Deliberately minimal beyond this. Nothing in `src/` yet consumes `PropertyVisibility` at
+ * runtime: the existing `Visibility: observable` / `Visibility: occluded` JSDoc annotations
+ * scattered through `artefact.ts` are prose, not references to this type, and migrating them onto
+ * it is a separate, later task. A branded wrapper, a per-level metadata table, or an
+ * ordering/comparison helper would all be speculative until `lens.ts` (roadmap 1FD.20), the first
+ * real consumer, gives visibility a concrete shape to design against.
+ */

--- a/src/lib/types/world.ts
+++ b/src/lib/types/world.ts
@@ -1,0 +1,483 @@
+/**
+ * World-generation type definitions: seed, chronology, culture, inter-culture relationships and
+ * site provenance (doc 05 §2, §3.1–§3.6). These describe the `WorldState`'s occluded generative
+ * substrate — the player never reads a `Culture` or a `WorldChronology` directly, but must infer
+ * their structure from observable artefact properties (doc 05 §3). This module is data shapes
+ * only, no behaviour; chronology and culture generation itself lives under `engine/world/`
+ * (roadmap 2GN.*, 3WS.*).
+ *
+ * Visibility (doc 05 §1.1) is expressed in prose JSDoc per field for now; roadmap 1FD.32 will add
+ * a `PropertyVisibility` enum (`observable` | `inferable` | `occluded` | `engine-internal`) that
+ * these annotations will migrate onto, per the convention set in artefact.ts.
+ */
+
+import type { MaterialTag } from './tags.ts';
+
+/**
+ * Stage 1 of the generation pipeline (doc 05 §2): a single seed string deterministically generates
+ * all downstream content. Same seed produces the same *sequence* of artefacts — artefact N may
+ * depend on artefacts 1 through N-1 (associated finds, site reuse, material precedent), so the
+ * guarantee is over the sequence, not each artefact in isolation.
+ *
+ * Not serialisable as-is: `prng` is a live closure over generator state, not data. Persisting and
+ * restoring world state across sessions is a future save-system concern (roadmap 1FD.33,
+ * `persistence/save.ts`), not this task's problem — whatever that system does, it won't be storing
+ * this closure verbatim.
+ */
+export interface WorldSeed {
+	/** The raw seed string as entered or generated. */
+	raw: string;
+
+	/** Seeded, deterministic PRNG (xoshiro128**) derived from `raw` (doc 05 §2). */
+	prng: () => number;
+}
+
+/**
+ * Multi-attribute description of a cultural phase (doc 05 §3.2) — four independent axis groups
+ * rather than a single float, so a culture can be exceptional metalworkers with crude ceramics.
+ * These attributes feed grammar expansion and the decorative layer as weight modifiers: high
+ * `technology.metallurgy` increases metal-compatible component probability, high
+ * `society.craftSpecialisation` raises the plausibility checker's part budget and the decorative
+ * grammar's recursion cap, high `aesthetics.formConservatism` narrows grammar branch variance.
+ * Visibility: occluded (the player infers phase character from artefacts, never reads this).
+ */
+export interface PhaseCharacteristics {
+	/** Craft technology maturity by domain, each 0–1. */
+	technology: {
+		/** Metalworking sophistication. Increases metal-compatible component probability. */
+		metallurgy: number;
+
+		/** Ceramic technology sophistication. */
+		ceramics: number;
+
+		/** Textile technology sophistication. */
+		textiles: number;
+
+		/** Stone-working technology sophistication. */
+		stoneWorking: number;
+
+		/** Glass-working technology sophistication. */
+		glassWorking: number;
+
+		/** Wood-working technology sophistication. */
+		woodWorking: number;
+	};
+
+	/** Economic structure, each 0–1. */
+	economy: {
+		/** Openness to foreign trade. Affects foreign material availability. */
+		tradeOpenness: number;
+
+		/** Economic surplus. Affects craft specialisation capacity. */
+		surplus: number;
+
+		/** Degree of urbanisation. Affects artefact density and diversity. */
+		urbanisation: number;
+	};
+
+	/** Social structure, each 0–1. */
+	society: {
+		/** Social stratification. Affects elite/utilitarian distribution. */
+		stratification: number;
+
+		/** Degree of militarisation. Affects weapon-adjacent forms. */
+		militarisation: number;
+
+		/** Religious emphasis. Affects ritual-adjacent forms. */
+		religiousEmphasis: number;
+
+		/** Craft specialisation. Affects part count and complexity budgets. */
+		craftSpecialisation: number;
+	};
+
+	/** Aesthetic tendencies, each 0–1. */
+	aesthetics: {
+		/** Emphasis on decoration. Affects decorative component budgets. */
+		decorativeEmphasis: number;
+
+		/** Complexity of motif work. Affects engraving/inlay sophistication. */
+		motifComplexity: number;
+
+		/** Formal conservatism. High values mean less variation between artefacts. */
+		formConservatism: number;
+	};
+}
+
+/**
+ * One named period within a single culture's own periodisation (doc 05 §3.1). There is no
+ * monolithic world timeline with shared periods; each culture's phases are its own, and overlaps
+ * with other cultures' phases are temporal coincidence the player must work out, not a shared
+ * label. Visibility: occluded.
+ */
+export interface CulturePhase {
+	/** Stable phase id, referenced by `Provenance.phaseId`. */
+	id: string;
+
+	/** Human-readable phase name (e.g. 'Expansion', 'Settlement', 'Fragmentation'). */
+	label: string;
+
+	/** First year of the phase. */
+	startYear: number;
+
+	/** Last year of the phase. */
+	endYear: number;
+
+	/** The phase's multi-attribute profile (doc 05 §3.2). */
+	characteristics: PhaseCharacteristics;
+}
+
+/**
+ * A single culture's full periodisation (doc 05 §3.1) — an ordered sequence of `CulturePhase`
+ * entries. Referenced by `WorldChronology.cultureTimelines` and by `Culture.timeline`.
+ * Visibility: occluded.
+ */
+export interface CultureTimeline {
+	/** Id of the culture this timeline belongs to. */
+	cultureId: string;
+
+	/** The culture's phases, in chronological order. */
+	phases: CulturePhase[];
+}
+
+/**
+ * Provisional, not doc-specified: the docs name `CulturalProfile.motifVocabulary`'s type and
+ * describe its role in prose (doc 05 §8.5 — motifs are the primary cultural fingerprint on the
+ * decorative layer, drawn from the source culture's motif vocabulary) but never give it a shape.
+ * This is the minimal shape that lets a `DecorativeLayer.motifRef` (`decoration.ts`) name one of
+ * these entries by `id`. Expect this to firm up when the decorative grammar engine lands.
+ */
+export interface MotifDefinition {
+	/** Stable id, referenced by `DecorativeLayer.motifRef` (`decoration.ts`) by value. */
+	id: string;
+
+	/** Human-readable motif name. */
+	label: string;
+
+	/** Id of the culture this motif originates from — supports borrowed-motif tracking (§8.5). */
+	culturalOrigin: string;
+}
+
+/**
+ * Provisional, not doc-specified: see `MotifDefinition`. A culture's full motif vocabulary, drawn
+ * from when assigning decoration (doc 05 §8.5).
+ */
+export interface MotifSet {
+	/** The motifs available to draw from. */
+	motifs: MotifDefinition[];
+}
+
+/**
+ * Where a culture channels its crafting energy (doc 05 §3.3) — not "make X% weapons", more "invest
+ * heavily in funerary goods". Biases production frequency, making some artefact contexts more
+ * common and others relatively rarer (doc 05 §10.2: semi-prescribed, a weight rather than a quota;
+ * actual production frequency emerges from the grammar running against these weights).
+ * Visibility: occluded.
+ */
+export interface CraftInvestmentProfile {
+	/** Weight per deposition context (e.g. heavy investment in `'burial-goods'`). */
+	contextWeights: Map<DepositionType, number>;
+
+	/** Weight per site type the culture tends to produce for. */
+	siteTypeWeights: Map<SiteType, number>;
+}
+
+/**
+ * A culture's stable material and craft tendencies (doc 05 §3.3), persisting across phases — a
+ * culture might always favour stone (`materialAffinities`) while its stone-working capability
+ * (`PhaseCharacteristics.technology.stoneWorking`) varies by phase. Visibility: occluded.
+ *
+ * Naming collision: doc 06 §3.3 defines an UNRELATED, differently-shaped type also called
+ * `CulturalProfile` — a player working-document with `cultureLabel`, `materialPreferences` and
+ * `functionalEmphasis` fields, part of the player's interpretive model, not world generation. This
+ * `world.ts` version is doc 05's world-generation profile. Do not confuse the two; they share a
+ * name across files but nothing else.
+ */
+export interface CulturalProfile {
+	/** Per-material-tag affinity weight, read by `GrammarOption.culturalModifiers` (grammar.ts). */
+	materialAffinities: Map<MaterialTag, number>;
+
+	/** The culture's decorative motif vocabulary (doc 05 §3.3, §8.5). */
+	motifVocabulary: MotifSet;
+
+	/** Where the culture channels its crafting energy (doc 05 §3.3). */
+	craftInvestment: CraftInvestmentProfile;
+}
+
+/**
+ * A generated culture (doc 05 §3.3): its stable profile plus its phase-by-phase periodisation.
+ * Visibility: occluded.
+ */
+export interface Culture {
+	/** Stable culture id, referenced by `CultureTimeline.cultureId` and `Provenance.cultureId`. */
+	id: string;
+
+	/** Human-readable culture name. */
+	label: string;
+
+	/** Stable tendencies that persist across phases (doc 05 §3.3). */
+	baseProfile: CulturalProfile;
+
+	/** The culture's periodisation (doc 05 §3.1). */
+	timeline: CultureTimeline;
+}
+
+/**
+ * A directional flow of a material tag between the two cultures in a `CultureRelationship` (doc 05
+ * §3.4). Part of `RelationshipDynamics.trade.materialFlow`. Visibility: occluded.
+ */
+export interface MaterialFlow {
+	/** The material tag flowing between cultures. */
+	materialTag: MaterialTag;
+
+	/** Optional specific material ids, when the flow is narrower than the whole tag. */
+	specificMaterials?: string[];
+
+	/** Which culture the material flows from and to, keyed against `CultureRelationship.cultureIds`. */
+	direction:
+		| 'a-to-b'
+		| 'b-to-a'
+		| 'bidirectional';
+
+	/** Volume of the flow, 0–1. */
+	volume: number;
+}
+
+/**
+ * The full multi-axis character of a relationship between two cultures during one
+ * `RelationshipPhase` (doc 05 §3.4). Trade, conflict, cultural exchange and political status are
+ * independent axes that can co-occur — a relationship can simultaneously involve trade in
+ * materials and low-level raiding. The player seeing Culture A artefacts with Culture B materials
+ * can't simply conclude "they traded"; the relationship data supports multiple explanations at
+ * once. Visibility: occluded.
+ */
+export interface RelationshipDynamics {
+	/** Trade axis. */
+	trade: {
+		/** Trade volume, 0–1. */
+		volume: number;
+
+		/** Which materials flow, and in which direction (doc 05 §3.4). */
+		materialFlow: MaterialFlow[];
+
+		/** Whether trade is roughly even or skewed towards one culture. */
+		directionality: 'balanced' | 'asymmetric';
+
+		/** Which culture dominates the trade, when `directionality` is `'asymmetric'`. */
+		dominantCulture?: string;
+	};
+
+	/** Conflict axis. */
+	conflict: {
+		/** Conflict intensity, 0–1. */
+		intensity: number;
+
+		/** The nature of the conflict, or `'none'` when the cultures are not in conflict. */
+		type: 'raiding' | 'territorial' | 'conquest' | 'none';
+	};
+
+	/** Cultural exchange axis (motifs, techniques, materials, forms crossing between cultures). */
+	culturalExchange: {
+		/** Exchange intensity, 0–1. */
+		intensity: number;
+
+		/** Which domains are being exchanged. */
+		domains: ('motifs' | 'techniques' | 'materials' | 'forms')[];
+	};
+
+	/** Political axis. */
+	political: {
+		/** The nature of the political relationship. */
+		type: 'independent' | 'tributary' | 'alliance' | 'vassal' | 'colonial';
+
+		/** Which culture dominates politically, when the type implies asymmetry. */
+		dominantCulture?: string;
+	};
+}
+
+/**
+ * One temporal window of a `CultureRelationship` (doc 05 §3.4) — relationships are temporal
+ * ranges, not static attributes; two cultures can trade in one window and fight in another.
+ * Visibility: occluded.
+ */
+export interface RelationshipPhase {
+	/** First year this dynamic holds. */
+	startYear: number;
+
+	/** Last year this dynamic holds. */
+	endYear: number;
+
+	/** The relationship's character during this window (doc 05 §3.4). */
+	dynamics: RelationshipDynamics;
+}
+
+/**
+ * The full temporal relationship history between two cultures (doc 05 §3.4). Referenced by
+ * `WorldChronology.relationships`. Visibility: occluded.
+ */
+export interface CultureRelationship {
+	/** The two cultures in this relationship, order matching `RelationshipDynamics` "a"/"b" axes. */
+	cultureIds: [string, string];
+
+	/** The relationship's phases, in chronological order. */
+	phases: RelationshipPhase[];
+}
+
+/**
+ * The culture-relative chronology for the whole generated world (doc 05 §3.1) — there is no
+ * monolithic shared timeline; each culture has its own periodisation, and interactions between
+ * cultures are defined by temporal overlap, not shared phase labels. `presentYear` anchors the
+ * chronology to the player's working moment: the difference between `presentYear` and an
+ * artefact's provenance `year` is its true age, but this is hidden from the player (absolute
+ * dating is not free information, doc 05 §4.7). Visibility: occluded.
+ */
+export interface WorldChronology {
+	/** Earliest point in the timeline across all cultures. */
+	startYear: number;
+
+	/** Latest point in the timeline (last cultural activity). */
+	endYear: number;
+
+	/** "Now" — the year the player is working. */
+	presentYear: number;
+
+	/** Every culture's own periodisation. */
+	cultureTimelines: CultureTimeline[];
+
+	/** Every pairwise inter-culture relationship generated for this world. */
+	relationships: CultureRelationship[];
+}
+
+/**
+ * The eleven kinds of location an artefact may be excavated from (doc 05 §3.5). Referenced by
+ * `Provenance.site.type` and by `CraftInvestmentProfile.siteTypeWeights`. Visibility: observable
+ * (the excavation context is directly known to the player).
+ */
+export type SiteType =
+	| 'settlement'
+	| 'burial'
+	| 'workshop'
+	| 'midden'
+	| 'shrine'
+	| 'cache'
+	| 'shipwreck'
+	| 'battlefield'
+	| 'market'
+	| 'fortification'
+	| 'quarry';
+
+/**
+ * How well an artefact survived to excavation (doc 05 §3.5). Referenced by `Provenance.context.
+ * condition`. Visibility: observable.
+ */
+export type PreservationState =
+	| 'excellent'
+	| 'good'
+	| 'fair'
+	| 'poor'
+	| 'fragmentary';
+
+/**
+ * How an artefact came to be deposited (doc 05 §3.5) — critical for interpretation. A blade in a
+ * `'deliberate-placement'` context within a shrine site reads very differently from the same blade
+ * in a `'casual-discard'` context within a settlement, even though the physical object is
+ * identical. Referenced by `Provenance.context.deposition` and by `CraftInvestmentProfile.
+ * contextWeights`. Visibility: observable (the deposition context is recorded at excavation), but
+ * its interpretive significance is inferable.
+ */
+export type DepositionType =
+	| 'deliberate-placement'
+	| 'casual-discard'
+	| 'destruction'
+	| 'burial-goods'
+	| 'foundation-deposit'
+	| 'hoard'
+	| 'loss'
+	| 'abandonment'
+	| 'unknown';
+
+/**
+ * Chronological, cultural, site and depositional context for a single artefact (doc 05 §3.5). The
+ * `site` and `context` groups are kept inline, matching the doc's own code block (see
+ * `NormalisedComponent.arrangementGroup` in artefact.ts for the same inline-nesting precedent).
+ * Visibility: occluded — the player must infer culture, phase and dating from artefact properties;
+ * this is the ground truth the engine checks claims against.
+ *
+ * Distinct from `MaterialProvenance` in artefact.ts: that type describes where an assigned
+ * material's raw source likely came from (local/regional/trade/unknown). This `Provenance`
+ * describes the artefact's own site, chronology and deposition context — a different axis
+ * entirely, and the two are not to be conflated despite the similar name.
+ */
+export interface Provenance {
+	/** Id of the culture that produced the artefact. */
+	cultureId: string;
+
+	/** Id of the `CulturePhase` the artefact was produced within. */
+	phaseId: string;
+
+	/** The year the artefact was deposited. */
+	year: number;
+
+	/** The excavation site. Kept inline per doc 05 §3.5. */
+	site: {
+		/** Site name. */
+		name: string;
+
+		/** Kind of site. */
+		type: SiteType;
+
+		/** Broad geographic region the site sits within. */
+		region: string;
+	};
+
+	/** The deposition context. Kept inline per doc 05 §3.5. */
+	context: {
+		/** Stratigraphic layer identifier. */
+		layer: string;
+
+		/** Ids of other artefacts recovered in direct association with this one. */
+		associatedFinds: string[];
+
+		/** How well the artefact survived to excavation. */
+		condition: PreservationState;
+
+		/** How the artefact came to be deposited (doc 05 §3.5). */
+		deposition: DepositionType;
+	};
+}
+
+/**
+ * How available a material is within a region, before cultural preference applies (doc 05 §3.6).
+ * A culture can want gold all it likes; if there's no gold source within trade range, it doesn't
+ * get gold unless it trades for it. Visibility: occluded (world-generation constraint, never
+ * exposed directly to the player).
+ */
+export type AvailabilityLevel =
+	| 'abundant' // Local source, no constraints
+	| 'available' // Present but not unlimited
+	| 'scarce' // Limited deposits, competes with other uses
+	| 'trade-only' // Not locally available, requires trade
+	| 'absent'; // Not available even through trade at current relationships
+
+/**
+ * One material's availability across every region of the world (doc 05 §3.6). A culture can
+ * *want* gold all it likes; if there's no gold source within trade range, it doesn't get gold
+ * unless it trades for it. Visibility: occluded.
+ */
+export interface RegionalAvailability {
+	/** Id of the material this availability map describes. */
+	materialId: string;
+
+	/** Availability level keyed by region name. */
+	regions: Map<string, AvailabilityLevel>;
+}
+
+/**
+ * World-level geological material scarcity (doc 05 §3.6), constraining cultural material
+ * preferences before they apply. Obsidian comes from volcanic geology; gold is geologically rare;
+ * tin for bronze requires specific deposits. Prescribed once at world generation and doesn't
+ * change (doc 05 §10.1). Visibility: occluded.
+ */
+export interface GeologicalContext {
+	/** Availability keyed by material id. */
+	materialAvailability: Map<string, RegionalAvailability>;
+}


### PR DESCRIPTION
## Overview
This PR builds out twelve foundational TypeScript type-definition tasks from the MVP roadmap's Milestone 1 (1FD.11, 13, 14, 15, 16, 18, 26, 32), giving the game's generation pipeline, world-simulation layer, career system and interpretive model real shapes to build against instead of design-doc prose. No runtime behaviour changes — these are pure data-shape declarations.

## Summary
Think of it like furnishing a house before anyone's allowed to move in. Nobody's living here yet — no grammar engine generating pots, no NPC scholars gossiping about your reputation — but every room now has a properly labelled cupboard, a shelf that's the right shape for what's meant to go on it, and a sticky note on the two shelves we haven't built yet explaining exactly what will eventually sit there and who's bringing it.

> [!TIP]
> No action needed after pulling — this is additive, type-only, and nothing on `main` currently imports any of it. `deno task check` should pass clean.

---
## Changes

<details>
<summary><code>src/lib/types/artefact.ts</code> — 11 types (roadmap 1FD.11)</summary>

`NormalisedArtefact`, `NormalisedComponent`, `Attachment`, `ObjectDimensions`, `Portability`, `InspectionDepth`, `ClassifiedArtefact`, `ExtractedFeatures`, `MaterialAssignment`, `MaterialDefinition`, `MaterialProvenance` — the structural, material and classification shapes for the artefact generation pipeline (doc 05 §5.2, §6.1, §7, §9).

</details>

<details>
<summary><code>src/lib/types/decoration.ts</code> — new file (roadmap 1FD.13)</summary>

`DecorativeTechnique`, `DecorativeLayer` — the decorative grammar's sixteen techniques and the recursive layer shape that lets one act of craft be decorated on top of another.

</details>

<details>
<summary><code>src/lib/types/world.ts</code> — new file, 21 types (roadmap 1FD.14, 1FD.15, 1FD.16)</summary>

World seed, chronology, culture, inter-culture relationships and site provenance — everything the generation pipeline needs to know about a simulated world before an artefact ever gets made. Three roadmap tasks landed together since they share cross-references within one file.

</details>

<details>
<summary><code>src/lib/types/interpretation.ts</code> — new file (roadmap 1FD.18)</summary>

`Observation`, `Inference`, `EvidenceLink`, `InferenceScope`, `Hypothesis`, `Confidence`, `InterpretiveModel` — the agent-generic shape shared by the player and every NPC scholar's subjective knowledge state.

</details>

<details>
<summary><code>src/lib/types/career.ts</code> — new file (roadmap 1FD.26)</summary>

`Reputation`, `ReputationModifier`, `ReputationGate`, `CareerState`, `AcademicRole`, `CareerActivity`, `ActivityType` — the academic career and reputation model.

</details>

<details>
<summary><code>src/lib/types/visibility.ts</code> — new file (roadmap 1FD.32)</summary>

`PropertyVisibility` plus minimal helpers — formalises the observable/inferable/occluded/engine-internal visibility model that governs what the player can ever know.

</details>

<details>
<summary><code>src/lib/types/tags.ts</code> — minor fix</summary>

Corrected a stale doc-section citation for `DepositionType` (§3.3 → §3.5). No exported symbol changed.

</details>

<details>
<summary><code>docs/roadmaps/mvp.md</code> — bookkeeping</summary>

Ticked all twelve completed tasks, refreshed the dependency graph, and marked five newly-unblocked tasks (1FD.17, 1FD.19, 1FD.20, 1FD.28, 1FD.31) as open.

</details>

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the MVP roadmap to reflect revised completion/progress states and reshuffled task lists for Milestone 1 and the Progress Map.
* **Chores / Refactor**
  * Expanded the project’s structured type definitions (data-only) covering artefacts, careers, interpretation, tags, property visibility, decoration, and world-building, including improved reuse of shared definitions for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->