### PR TITLE
Wire Up Test Fixtures For Cultures And Artefacts

### DIFF
--- a/docs/roadmaps/mvp.md
+++ b/docs/roadmaps/mvp.md
@@ -64,10 +64,6 @@ description: MVP implementation roadmap from foundation through NPC social syste
 - [ ] 1FD.31. `src/lib/types/description.ts` — `DescriptionTemplate`, `DescriptionVariant`, `ArtefactPresentation`, `PresentedObservation`, `TagSuggestion`, `ProvenancePresentation`, `DescriptionRegister` (`'observational' | 'interpretive' | 'technical'` per doc 04 §3.4; the five-value `ObservationRegister` + `RegisterAccess` acquisition model from doc 05 §12 is post-MVP)
 - [ ] 1FD.33. `src/lib/types/save.ts` — `SaveFile`, `SerialisedWorldState`, `SerialisedInterpretiveModel`, `SerialisedTermState`, `CURRENT_SAVE_VERSION`
 
-**Test infrastructure**
-
-- [ ] 1FD.35. Create test fixture helpers — mock culture, mock world seed, mock artefact factories (partially done: `tests/fixtures/world.ts` has `mockWorldSeed`; mock culture unblocked — `Culture`/`CulturalProfile` (1FD.14), `SiteType`/`DepositionType` (1FD.16) and `MaterialTag` (1FD.12) now exist; mock artefact unblocked — `NormalisedArtefact`/`ClassifiedArtefact` (1FD.11), `ArrangementPattern`/`AttachmentType` (1FD.10) and `MaterialTag` (1FD.12) now exist)
-
 **Project Explorer shell**
 
 - [ ] 1FD.36. Create route `/dev/explorer` with layout and nav
@@ -111,6 +107,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 **Test infrastructure**
 
 - [x] 1FD.34. Configure `deno test`, verify runner executes against engine skeleton (`deno task test` wired in `deno.json`; `@std/assert@^1.0.19` added; `tsconfig.json` excludes `*.test.ts` from `svelte-check` since Deno test files use `Deno.ns`/`jsr:` specifiers svelte-check can't resolve)
+- [x] 1FD.35. Create test fixture helpers — mock culture, mock world seed, mock artefact factories (split per-domain, mirroring `src/lib/types/`: `tests/fixtures/world.ts` keeps `mockWorldSeed`, now returning the real `WorldSeed` instead of a local stand-in; `tests/fixtures/culture.ts` adds `mockCulture`; `tests/fixtures/artefact.ts` adds `mockNormalisedArtefact` and `mockArtefact`; each takes a shallow-merge `overrides` param that replaces whole top-level branches rather than deep-merging, since several fields are `Map`s or multi-level nested objects; `tsconfig.json`'s `exclude` extended to `tests/**/*.test.ts` alongside the existing `src/**/*.test.ts` for the same Deno-only reason)
 </details>
 
 <details>

--- a/tests/fixtures/artefact.test.ts
+++ b/tests/fixtures/artefact.test.ts
@@ -1,0 +1,60 @@
+/// <reference lib="deno.ns" />
+import { assert, assertEquals } from '@std/assert';
+import { mockArtefact, mockNormalisedArtefact } from './artefact.ts';
+
+Deno.test('mockNormalisedArtefact: has one component and no attachments by default', () => {
+	const artefact = mockNormalisedArtefact();
+
+	assertEquals(artefact.components.length, 1);
+	assertEquals(artefact.attachments.length, 0);
+	assertEquals(artefact.dimensions.mass, 'light');
+});
+
+Deno.test('mockNormalisedArtefact: overrides apply', () => {
+	const artefact = mockNormalisedArtefact({ id: 'custom-artefact' });
+
+	assertEquals(artefact.id, 'custom-artefact');
+});
+
+Deno.test('mockArtefact: extends the normalised base with classification fields', () => {
+	const artefact = mockArtefact();
+
+	// Inherited NormalisedArtefact fields.
+	assertEquals(artefact.components.length, 1);
+	assertEquals(artefact.attachments.length, 0);
+
+	// Classification fields.
+	assert(artefact.groundTruthTags instanceof Map);
+	assert(artefact.groundTruthTags.size > 0);
+	assertEquals(artefact.decorativeLayers.length, 0);
+	assertEquals(artefact.materialProvenance.length, 0);
+	assert(typeof artefact.physicalLabel === 'string' && artefact.physicalLabel.length > 0);
+});
+
+Deno.test('mockArtefact: materials reference the base component by id', () => {
+	const artefact = mockArtefact();
+
+	assertEquals(artefact.materials[0].componentId, artefact.components[0].id);
+});
+
+Deno.test('mockArtefact: features carries all required fields', () => {
+	const { features } = mockArtefact();
+
+	assertEquals(typeof features.hasEdge, 'boolean');
+	assertEquals(typeof features.partCount, 'number');
+	assertEquals(features.primaryAxisLength, 'medium');
+	assertEquals(features.portability, 'one-hand');
+});
+
+Deno.test('mockArtefact: provenance site and context are populated', () => {
+	const { provenance } = mockArtefact();
+
+	assertEquals(provenance.site.type, 'settlement');
+	assertEquals(provenance.context.deposition, 'casual-discard');
+});
+
+Deno.test('mockArtefact: overrides apply', () => {
+	const artefact = mockArtefact({ physicalLabel: 'custom label' });
+
+	assertEquals(artefact.physicalLabel, 'custom label');
+});

--- a/tests/fixtures/artefact.ts
+++ b/tests/fixtures/artefact.ts
@@ -1,0 +1,150 @@
+/**
+ * Test fixtures for `NormalisedArtefact` and `ClassifiedArtefact` (doc 05 §6.1, §9.3, roadmap
+ * task 1FD.35).
+ *
+ * Consumed as named imports with an explicit `.ts` extension, matching the convention set by
+ * `src/lib/engine/prng.test.ts`. Sibling to `tests/fixtures/world.ts` (seed) and
+ * `tests/fixtures/culture.ts` (culture) — fixtures are split per-domain to mirror the
+ * `src/lib/types/` layout.
+ */
+
+import type {
+	ClassifiedArtefact,
+	ExtractedFeatures,
+	MaterialAssignment,
+	NormalisedArtefact,
+	NormalisedComponent,
+	ObjectDimensions,
+} from '../../src/lib/types/artefact.ts';
+import type { ContextTag, FunctionTag } from '../../src/lib/types/tags.ts';
+import type { Provenance } from '../../src/lib/types/world.ts';
+
+function mockDimensions(): ObjectDimensions {
+	return {
+		primaryExtent: 20,
+		secondaryExtent: 4,
+		mass: 'light',
+	};
+}
+
+function mockComponent(): NormalisedComponent {
+	return {
+		id: 'test-component',
+		primitiveType: 'elongated',
+		properties: new Map<string, string | number>([
+			['length', 20],
+			['crossSection', 'round'],
+		]),
+		allowedMaterialTags: ['metal', 'wood'],
+		position: 0,
+	};
+}
+
+function mockExtractedFeatures(): ExtractedFeatures {
+	return {
+		hasEdge: true,
+		edgeCount: 1,
+		hasPoint: true,
+		hasImpactSurface: false,
+		hasContainer: false,
+		containerOpenness: 0,
+		hasFasteningMechanism: false,
+		primaryAxisLength: 'medium',
+		isWearable: false,
+		partCount: 1,
+		attachmentDiversity: 0,
+		decorativeLayerCount: 0,
+		motifPresent: false,
+		motifCulturalOrigins: [],
+		techniqueComplexity: 0,
+		preciousMaterialsInDecoration: false,
+		functionalComplexity: 0.5,
+		decorativeComplexity: 0,
+		overallComplexity: 0.5,
+		portability: 'one-hand',
+		inspectionDepth: 'full',
+	};
+}
+
+function mockProvenance(): Provenance {
+	return {
+		cultureId: 'test-culture',
+		phaseId: 'test-phase',
+		year: -250,
+		site: {
+			name: 'Test Site',
+			type: 'settlement',
+			region: 'Test Region',
+		},
+		context: {
+			layer: 'layer-1',
+			associatedFinds: [],
+			condition: 'good',
+			deposition: 'casual-discard',
+		},
+	};
+}
+
+/**
+ * Builds a mock `NormalisedArtefact`: a single component, no attachments, valid dimensions,
+ * `one-hand` portability and `full` inspection depth.
+ *
+ * Overrides replace whole top-level branches (`dimensions`, `components`) rather than
+ * deep-merging — a fixture caller wanting a different component set should pass the full
+ * `components` array. See `mockCulture` (`tests/fixtures/culture.ts`) for the same convention.
+ *
+ * @param overrides - Partial `NormalisedArtefact` merged shallowly over the defaults.
+ */
+export function mockNormalisedArtefact(
+	overrides: Partial<NormalisedArtefact> = {},
+): NormalisedArtefact {
+	const defaults: NormalisedArtefact = {
+		id: 'test-artefact',
+		components: [mockComponent()],
+		attachments: [],
+		dimensions: mockDimensions(),
+		portability: 'one-hand',
+		inspectionDepth: 'full',
+	};
+
+	return { ...defaults, ...overrides };
+}
+
+/**
+ * Builds a mock `ClassifiedArtefact`: a `mockNormalisedArtefact` base plus one material
+ * assignment, no decorative layers, a full `ExtractedFeatures` set, ground-truth tags, a neutral
+ * physical label and a valid `Provenance`. `materials[0].componentId` matches the base
+ * component's `id` by default so the fixture reads coherently on its own.
+ *
+ * Overrides replace whole top-level branches rather than deep-merging, matching
+ * `mockNormalisedArtefact` and `mockCulture`.
+ *
+ * @param overrides - Partial `ClassifiedArtefact` merged shallowly over the defaults.
+ */
+export function mockArtefact(overrides: Partial<ClassifiedArtefact> = {}): ClassifiedArtefact {
+	const base = mockNormalisedArtefact();
+
+	const materials: MaterialAssignment[] = [
+		{
+			componentId: base.components[0].id,
+			materialId: 'bronze',
+			provenance: { source: 'local' },
+		},
+	];
+
+	const defaults: ClassifiedArtefact = {
+		...base,
+		materials,
+		decorativeLayers: [],
+		features: mockExtractedFeatures(),
+		groundTruthTags: new Map<FunctionTag | ContextTag, number>([
+			['tool', 0.8],
+			['utilitarian', 0.6],
+		]),
+		physicalLabel: 'short bronze elongated form',
+		provenance: mockProvenance(),
+		materialProvenance: [],
+	};
+
+	return { ...defaults, ...overrides };
+}

--- a/tests/fixtures/culture.test.ts
+++ b/tests/fixtures/culture.test.ts
@@ -1,0 +1,46 @@
+/// <reference lib="deno.ns" />
+import { assert, assertEquals } from '@std/assert';
+import { mockCulture } from './culture.ts';
+
+Deno.test('mockCulture: id and timeline.cultureId are consistent by default', () => {
+	const culture = mockCulture();
+
+	assertEquals(culture.timeline.cultureId, culture.id);
+});
+
+Deno.test('mockCulture: materialAffinities is a populated Map', () => {
+	const culture = mockCulture();
+
+	assert(culture.baseProfile.materialAffinities instanceof Map);
+	assert(culture.baseProfile.materialAffinities.size > 0);
+});
+
+Deno.test('mockCulture: craftInvestment weights are populated Maps', () => {
+	const culture = mockCulture();
+
+	assert(culture.baseProfile.craftInvestment.contextWeights instanceof Map);
+	assert(culture.baseProfile.craftInvestment.contextWeights.size > 0);
+	assert(culture.baseProfile.craftInvestment.siteTypeWeights instanceof Map);
+	assert(culture.baseProfile.craftInvestment.siteTypeWeights.size > 0);
+});
+
+Deno.test('mockCulture: timeline has at least one fully-populated phase', () => {
+	const culture = mockCulture();
+
+	assert(culture.timeline.phases.length > 0);
+
+	const [phase] = culture.timeline.phases;
+	const { technology, economy, society, aesthetics } = phase.characteristics;
+
+	assertEquals(typeof technology.metallurgy, 'number');
+	assertEquals(typeof economy.tradeOpenness, 'number');
+	assertEquals(typeof society.craftSpecialisation, 'number');
+	assertEquals(typeof aesthetics.decorativeEmphasis, 'number');
+});
+
+Deno.test('mockCulture: overrides apply', () => {
+	const culture = mockCulture({ id: 'custom-culture', label: 'Custom Culture' });
+
+	assertEquals(culture.id, 'custom-culture');
+	assertEquals(culture.label, 'Custom Culture');
+});

--- a/tests/fixtures/culture.ts
+++ b/tests/fixtures/culture.ts
@@ -1,0 +1,118 @@
+/**
+ * Test fixture for `Culture` (doc 05 §3.3, roadmap task 1FD.35).
+ *
+ * Consumed as a named import with an explicit `.ts` extension, matching the convention set by
+ * `src/lib/engine/prng.test.ts`. Sibling to `tests/fixtures/world.ts` (seed) and
+ * `tests/fixtures/artefact.ts` (artefacts) — fixtures are split per-domain to mirror the
+ * `src/lib/types/` layout.
+ */
+
+import type {
+	CraftInvestmentProfile,
+	CulturalProfile,
+	Culture,
+	CulturePhase,
+	CultureTimeline,
+	MotifSet,
+	PhaseCharacteristics,
+} from '../../src/lib/types/world.ts';
+import type { MaterialTag } from '../../src/lib/types/tags.ts';
+
+function mockPhaseCharacteristics(): PhaseCharacteristics {
+	return {
+		technology: {
+			metallurgy: 0.5,
+			ceramics: 0.5,
+			textiles: 0.5,
+			stoneWorking: 0.5,
+			glassWorking: 0.5,
+			woodWorking: 0.5,
+		},
+		economy: {
+			tradeOpenness: 0.5,
+			surplus: 0.5,
+			urbanisation: 0.5,
+		},
+		society: {
+			stratification: 0.5,
+			militarisation: 0.5,
+			religiousEmphasis: 0.5,
+			craftSpecialisation: 0.5,
+		},
+		aesthetics: {
+			decorativeEmphasis: 0.5,
+			motifComplexity: 0.5,
+			formConservatism: 0.5,
+		},
+	};
+}
+
+function mockMotifVocabulary(cultureId: string): MotifSet {
+	return {
+		motifs: [
+			{ id: 'test-motif', label: 'Test Motif', culturalOrigin: cultureId },
+		],
+	};
+}
+
+function mockCraftInvestment(): CraftInvestmentProfile {
+	return {
+		contextWeights: new Map([
+			['burial-goods', 1.0],
+			['deliberate-placement', 0.5],
+		]),
+		siteTypeWeights: new Map([
+			['settlement', 1.0],
+			['burial', 0.75],
+		]),
+	};
+}
+
+function mockBaseProfile(cultureId: string): CulturalProfile {
+	return {
+		materialAffinities: new Map<MaterialTag, number>([
+			['metal', 1.5],
+			['stone', 1.0],
+		]),
+		motifVocabulary: mockMotifVocabulary(cultureId),
+		craftInvestment: mockCraftInvestment(),
+	};
+}
+
+function mockTimeline(cultureId: string): CultureTimeline {
+	const phase: CulturePhase = {
+		id: 'test-phase',
+		label: 'Test Phase',
+		startYear: -500,
+		endYear: 0,
+		characteristics: mockPhaseCharacteristics(),
+	};
+
+	return { cultureId, phases: [phase] };
+}
+
+/**
+ * Builds a mock `Culture`: a stable id/label, a fully-populated `baseProfile` (material
+ * affinities, motif vocabulary, craft investment) and a single-phase `timeline`. `timeline.
+ * cultureId` and `motifVocabulary.motifs[0].culturalOrigin` are kept consistent with `id` by
+ * default so a fixture read alone still makes sense.
+ *
+ * Overrides replace whole top-level branches (`baseProfile`, `timeline`) rather than deep-merging
+ * — `materialAffinities`/`contextWeights`/`siteTypeWeights` are `Map`s and `PhaseCharacteristics`
+ * nests two levels deep, so a shallow spread on either would silently drop sibling entries.
+ * Callers wanting a tweaked phase or affinity map should pass the full replacement branch.
+ *
+ * @param overrides - Partial `Culture` merged shallowly over the defaults.
+ */
+export function mockCulture(overrides: Partial<Culture> = {}): Culture {
+	const id = overrides.id ?? 'test-culture';
+
+	const defaults: Culture = {
+		id,
+		label: 'Test Culture',
+		baseProfile: mockBaseProfile(id),
+		timeline: mockTimeline(id),
+	};
+
+	return { ...defaults, ...overrides };
+}

--- a/tests/fixtures/world.ts
+++ b/tests/fixtures/world.ts
@@ -1,36 +1,20 @@
 /**
- * Test fixtures for world-level types (doc 08 §5, roadmap task 1FD.35).
+ * Test fixture for the world seed (doc 08 §5, roadmap task 1FD.35).
  *
- * Consumed as `import * as fixtures from '../fixtures/world'` per the project's fixtures
- * convention. Only `mockWorldSeed` is implemented today — it's the one fixture that needs no
- * unbuilt domain types (see the TODOs below for what blocks the other two).
+ * Consumed as a named import with an explicit `.ts` extension, matching the convention set by
+ * `src/lib/engine/prng.test.ts` (e.g. `import { mockWorldSeed } from '../../../tests/fixtures/world.ts'`).
+ * Culture and artefact fixtures live alongside this one in `tests/fixtures/culture.ts` and
+ * `tests/fixtures/artefact.ts` — split per-domain to mirror the `src/lib/types/` layout.
  */
 
 import { createPrng } from '../../src/lib/engine/prng.ts';
+import type { WorldSeed } from '../../src/lib/types/world.ts';
 
 /**
- * Structural stand-in for `WorldSeed` (doc 05 §2). Declared locally rather than imported because
- * `src/lib/types/world.ts` (roadmap task 1FD.14) doesn't exist yet — swap this for the real type
- * import once that task lands.
- */
-export interface MockWorldSeed {
-	raw: string;
-	prng: () => number;
-}
-
-/**
- * Builds a mock `WorldSeed`: a raw seed string plus its deterministic PRNG. This is the only
- * fixture in 1FD.35 buildable before the type system exists, since `WorldSeed` needs nothing
- * beyond `createPrng` (1FD.6).
+ * Builds a mock `WorldSeed`: a raw seed string plus its deterministic PRNG (doc 05 §2).
  *
  * @param raw - Seed string. Defaults to a fixed value so callers get determinism for free.
  */
-export function mockWorldSeed(raw = 'test-seed'): MockWorldSeed {
+export function mockWorldSeed(raw = 'test-seed'): WorldSeed {
 	return { raw, prng: createPrng(raw) };
 }
-
-// TODO(1FD.35): mockCulture — blocked on Culture/CulturalProfile (1FD.14), MaterialTag (1FD.12),
-// SiteType/DepositionType (1FD.16). None of these types exist in src/lib/types/ yet.
-
-// TODO(1FD.35): mockArtefact — blocked on NormalisedArtefact/ClassifiedArtefact (1FD.11),
-// ArrangementPattern/AttachmentType (1FD.10), MaterialTag (1FD.12). None of these types exist yet.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,6 @@
 	},
 	// *.test.ts files are Deno-only (Deno.test, deno.ns lib, jsr: specifiers) and never bundled
 	// by Vite, so svelte-check shouldn't type-check them — `deno task test` covers them instead.
-	"exclude": ["src/**/*.test.ts"]
+	// tests/fixtures/*.test.ts (roadmap 1FD.35) hits the same issue, so it's excluded too.
+	"exclude": ["src/**/*.test.ts", "tests/**/*.test.ts"]
 }


### PR DESCRIPTION
## Overview
Completes roadmap task 1FD.35 by building the two remaining test fixture factories, `mockCulture` and `mockArtefact`, now that their underlying domain types have landed. `mockWorldSeed` also gets upgraded to return the real `WorldSeed` type instead of a placeholder stand-in.

## Summary
Think of the test suite as a museum that's been promised three galleries but has only ever had one open: the Seed Room. Visitors have been asking about the Culture Wing and the Artefact Wing for a while, and the builders kept saying "just waiting on the plumbing" (i.e. the `Culture` and `NormalisedArtefact`/`ClassifiedArtefact` type definitions). The plumbing's in. Both wings are now open, fully furnished with display cases (`Map`-typed material affinities, phase characteristics, extracted features, provenance) and a "customise your exhibit" request desk (`overrides` params) at the door.

> [!TIP]
> No action required after pulling this down. `deno task test` picks up the new fixture tests automatically.

---
## Changes

<details>
<summary><code>tests/fixtures/culture.ts</code> (new) — <code>mockCulture</code></summary>

Builds a fully-populated `Culture`: stable id/label, a `baseProfile` with `Map`-typed material affinities and craft investment weights, a motif vocabulary, and a single-phase `timeline` with complete `PhaseCharacteristics`. Cross-references (`timeline.cultureId`, motif `culturalOrigin`) default to matching the culture's own `id`.

Takes a shallow-merge `overrides` param — deliberately replaces whole top-level branches (`baseProfile`, `timeline`) rather than deep-merging, since several fields are `Map` instances or two-level-nested objects where a naive spread would silently drop sibling data.
</details>

<details>
<summary><code>tests/fixtures/artefact.ts</code> (new) — <code>mockNormalisedArtefact</code>, <code>mockArtefact</code></summary>

`mockNormalisedArtefact` builds a valid `NormalisedArtefact`: one component, no attachments, valid dimensions, portability and inspection depth.

`mockArtefact` extends that base into a full `ClassifiedArtefact`: material assignments, decorative layers, a complete `ExtractedFeatures` set, ground-truth tags, a physical label and provenance. `materials[0].componentId` defaults to matching the base component's `id`.

Same shallow-merge `overrides` convention as `mockCulture`.
</details>

<details>
<summary><code>tests/fixtures/world.ts</code> (modified)</summary>

`mockWorldSeed` now returns the real `WorldSeed` type instead of the local `MockWorldSeed` stand-in that existed only because `WorldSeed` hadn't landed yet. JSDoc updated to point at the new sibling fixture files.
</details>

<details>
<summary><code>tests/fixtures/culture.test.ts</code>, <code>tests/fixtures/artefact.test.ts</code> (new)</summary>

12 new Deno tests covering default shapes, `Map` field population, cross-referenced ids, and override behaviour for both new fixture files.
</details>

<details>
<summary><code>tsconfig.json</code> (modified)</summary>

Extends the `exclude` list to `tests/**/*.test.ts` alongside the existing `src/**/*.test.ts` — these Deno-only test files (using `Deno.test`, `deno.ns`, `jsr:` specifiers) hit the same `svelte-check` incompatibility.
</details>

<details>
<summary><code>docs/roadmaps/mvp.md</code> (modified)</summary>

Moves 1FD.35 from To Do to Completed with a note on what landed.
</details>

---