### PR TITLE
Foundation Types: Dating, Terms, Lens and Description

### DIFF
--- a/docs/roadmaps/mvp.md
+++ b/docs/roadmaps/mvp.md
@@ -6,7 +6,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 |          | Status                  | Next Up           | Blocked           |
 | -------- | ----------------------- | ----------------- | ----------------- |
-| **FD**   | In progress             | 1FD.17, 1FD.20, 1FD.28, 1FD.31 | — |
+| **FD**   | In progress             | 1FD.21, 1FD.24, 1FD.29, 1FD.36 | — |
 | **GN**   | Not started             | 2GN.1, 2GN.2, 2GN.17, 2GN.22 | —      |
 | **WS**   | Not started             | —                 | 2GN.56            |
 | **UI**   | Not started             | —                 | 3WS.15            |
@@ -50,18 +50,14 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 **Type system**
 
-- [ ] 1FD.17. `src/lib/types/world.ts` — `DatingFramework`, `LayerDating`, `DatingMethod`
-- [ ] 1FD.20. `src/lib/types/lens.ts` — `LensStrength`, `ObservationSalience`, `ClassificationSuggestion`, `CrossReference`, `DescriptionFrame`, `OmissionCheck`, `LensState`
 - [ ] 1FD.21. `src/lib/types/documents.ts` — `DocumentNode`, `DocumentLineage`, `DerivationType`, `DerivationEvent`, `DocumentScope`, `Audience`, `PublicationRegister`, `DocumentPerception` (simplified MVP shape per doc 10 §11: `audienceReach`, `takeawayDivergence`, `citationCount`)
 - [ ] 1FD.22. `src/lib/types/documents.ts` — `DisseminationState`, `DisseminationEvent`, `DisseminationDetails`, `PeerReviewState`, `Retraction`, `TaintedLineage`
 - [ ] 1FD.23. `src/lib/types/venues.ts` — `VenueDefinition`, `ContainerModel`, `TemporalMode`, `SubmissionWindow`, `EditorialProcess`, `AudienceEncounter`, `VenueScope`, `VenueClassification`
 - [ ] 1FD.24. `src/lib/types/contradiction.ts` — `Contradiction` union, `MaterialContradiction`, `TemporalContradiction`, `CulturalContradiction`, `StructuralContradiction`, `ProvenanceContradiction`, `CorpusContradiction`, `RarityContradiction`, `MaterialProvenanceContradiction` (all eight members per doc 06 §4.2; `CulturalContradiction.agentClaim` references a claimId at MVP — doc 06's profileId applies once cultural-profile documents land post-MVP)
 - [ ] 1FD.25. `src/lib/types/contradiction.ts` — `ContradictionSeverity`, `ContradictionQueue`, `QueuedContradiction`, `DiegeticSurface`, `Resolution`, `HypothesisStrain` (resolves the two cross-file `TODO(1FD.25)` stand-ins in `interpretation.ts`)
 - [ ] 1FD.27. `src/lib/types/career.ts` — `RoleRequirement`, `DisseminationCareerEffect`, `PeerReviewCareerEvent`, `ReviewerFeedback`
-- [ ] 1FD.28. `src/lib/types/term.ts` — `TermType`, `AcademicYear`, `TermState`, `BackgroundDrain`, `CompletedAction` (doc 08 §3.6 places both in term.ts), constants (`WEEKS_PER_TERM`, `TERMS_PER_YEAR`), helpers (`termStartWeek`, `weekInTerm`, `termIndexFromWeek`, `yearFromTerm`)
 - [ ] 1FD.29. `src/lib/types/scholars.ts` — `MinimalScholar`, `NPCScholarSeed`, `SimulatedExcavation`
 - [ ] 1FD.30. `src/lib/types/corpus.ts` — `ProfessionalCorpus`, `FrequencyRecord`, `ContextFrequency`, `ConsensusStatement`, `Debate`, `DebatePosition`, `CoverageBudget`
-- [ ] 1FD.31. `src/lib/types/description.ts` — `DescriptionTemplate`, `DescriptionVariant`, `ArtefactPresentation`, `PresentedObservation`, `TagSuggestion`, `ProvenancePresentation`, `DescriptionRegister` (`'observational' | 'interpretive' | 'technical'` per doc 04 §3.4; the five-value `ObservationRegister` + `RegisterAccess` acquisition model from doc 05 §12 is post-MVP)
 - [ ] 1FD.33. `src/lib/types/save.ts` — `SaveFile`, `SerialisedWorldState`, `SerialisedInterpretiveModel`, `SerialisedTermState`, `CURRENT_SAVE_VERSION`
 
 **Project Explorer shell**
@@ -103,6 +99,10 @@ description: MVP implementation roadmap from foundation through NPC social syste
 - [x] 1FD.19. `src/lib/types/interpretation.ts` — `MethodologicalBias`, `CulturalClaim`, `ArtefactClaim`, `ChronoClaim`, `AgentAssessment`, `MethodologicalProfile` (doc 08 §3.2 names all five as `InterpretiveModel` members but gives no field shapes; authored against downstream consumers instead — the contradiction detector's `agentClaim: { claimId, claim }` contract (doc 06 §4.2, 1FD.24) requires `id` + `claim: string` on the three claim types, and the player store's `Map` usage (doc 08 §3.4) requires `id`-keying and a `status` union including `'active'`, reusing the `'active' | 'challenged' | 'retracted'` union already on `Inference`/`Hypothesis`; `MethodologicalBias` is an authored union — `'materialist' | 'structuralist' | 'culturalist'` from doc 07 §5.1 plus an authored `'generalist'` neutral member so the union stays total (no optional `bias` field) and `MethodologicalProfile` has a sensible non-empty default (`bias: 'generalist'`, all `weights` at `1.0`) for the `defaultMethodology()` factory, 3WS.11; strain lives in `HypothesisStrain`, 1FD.25 — the name `StrainScore` is retired; resolves the five same-file `TODO(1FD.19)` stand-ins in `interpretation.ts`)
 - [x] 1FD.26. `src/lib/types/career.ts` — `Reputation`, `ReputationModifier`, `ReputationGate`, `CareerState`, `AcademicRole`, `CareerActivity`, `ActivityType` (doc 07 §2, §2.2, §4.0–§4.1, fully specified verbatim and self-contained; `CareerActivity.outcomes: ActivityOutcome[]` needed an invented, provisional `ActivityOutcome` shape — doc 07 names it only as a comment, "Possible results", with no roadmap task owning it)
 - [x] 1FD.32. `src/lib/types/visibility.ts` — `PropertyVisibility` (string-literal union, not a TS `enum`, per the convention already committed in `artefact.ts`'s module JSDoc), `PROPERTY_VISIBILITY_VALUES`, `isPropertyVisibility` (doc 11 §2.7 authoritative; helpers kept minimal since there's no consumer yet — `lens.ts`, 1FD.20, is the first)
+- [x] 1FD.17. `src/lib/types/world.ts` — `DatingFramework`, `LayerDating`, `DatingMethod` (doc 05 §4.7, fully specified verbatim; `DatingConfidence` hoisted from the doc's inline union on `DatingFramework.confidence` per the `ClaimStatus` precedent in interpretation.ts — `ProvenancePresentation.dating`, 1FD.31, is the second consumer)
+- [x] 1FD.28. `src/lib/types/term.ts` — `TermType`, `AcademicYear`, `TermState`, `BackgroundDrain`, `CompletedAction` (doc 08 §3.6 verbatim, which supersedes doc 07's older sketches per doc 12 §2.9), constants (`WEEKS_PER_TERM`, `TERMS_PER_YEAR`, plus `WEEKS_PER_YEAR` from the same doc block), helpers (`termStartWeek`, `weekInTerm`, `termIndexFromWeek`, `yearFromTerm`; all 0-based per doc 11 §2.8, covered by `term.test.ts`; `getTermType(termIndex)` deliberately excluded — it belongs to 9CR.20, `engine/career/progression.ts`)
+- [x] 1FD.20. `src/lib/types/lens.ts` — `LensStrength`, `ObservationSalience`, `ClassificationSuggestion`, `CrossReference`, `DescriptionFrame`, `OmissionCheck`, `LensState` (doc 04 §3.1–§3.5, §4, incl. the graduated dissemination factor with 0.15 presented per doc 12 §2.16; `LensState` is named by doc 06 §6 and 6LS.2/6LS.4 but shaped nowhere — landed as a flagged provisional design, per-hypothesis `strengths` Map + aggregated `tagWeights` + `computedAtTerm`, to firm up at 6LS.2/6LS.3; also owns `DescriptionRegister` (doc 04 §3.4), moved here from the 1FD.31 bullet because `DescriptionFrame` keys a `Record` on it and description.ts already imports lens.ts, keeping imports one-directional; resolves the `observationRegister` inline-union TODO in interpretation.ts from 1FD.18)
+- [x] 1FD.31. `src/lib/types/description.ts` — `DescriptionTemplate`, `DescriptionVariant`, `ArtefactPresentation`, `PresentedObservation`, `TagSuggestion`, `ProvenancePresentation` (doc 05 §13.1–§13.2; both `register` fields narrowed from the doc's five-value `ObservationRegister` to the three-value `DescriptionRegister` per doc 12 §2.10 — the five-register model + `RegisterAccess` is post-MVP, doc 13 §4; `DescriptionRegister` itself lives in lens.ts under 1FD.20, imported here; `ProvenancePresentation` is named by `ArtefactPresentation.provenance` but shaped nowhere — landed as a flagged provisional player-visible projection of world.ts `Provenance`, `cultureId`/`phaseId`/`year` deliberately absent with an optional corpus-derived `dating` block per doc 05 §4.7, to firm up at 2GN.38)
 
 **Test infrastructure**
 
@@ -680,21 +680,21 @@ graph TD
     1FD.14["`*1FD.14*<br/>types/world core`"]:::done
     1FD.15["`*1FD.15*<br/>types/world relations`"]:::done
     1FD.16["`*1FD.16*<br/>types/world provenance`"]:::done
-    1FD.17["`*1FD.17*<br/>types/world dating`"]:::open
+    1FD.17["`*1FD.17*<br/>types/world dating`"]:::done
     1FD.18["`*1FD.18*<br/>types/interpretation core`"]:::done
     1FD.19["`*1FD.19*<br/>types/interpretation claims`"]:::done
-    1FD.20["`*1FD.20*<br/>types/lens.ts`"]:::open
+    1FD.20["`*1FD.20*<br/>types/lens.ts`"]:::done
     1FD.21["`*1FD.21*<br/>types/documents core`"]:::open
     1FD.22["`*1FD.22*<br/>types/documents dissem`"]:::blocked
     1FD.23["`*1FD.23*<br/>types/venues.ts`"]:::blocked
-    1FD.24["`*1FD.24*<br/>types/contradiction core`"]:::blocked
+    1FD.24["`*1FD.24*<br/>types/contradiction core`"]:::open
     1FD.25["`*1FD.25*<br/>types/contradiction queue`"]:::blocked
     1FD.26["`*1FD.26*<br/>types/career core`"]:::done
     1FD.27["`*1FD.27*<br/>types/career drains`"]:::blocked
-    1FD.28["`*1FD.28*<br/>types/term.ts`"]:::open
-    1FD.29["`*1FD.29*<br/>types/scholars.ts`"]:::blocked
+    1FD.28["`*1FD.28*<br/>types/term.ts`"]:::done
+    1FD.29["`*1FD.29*<br/>types/scholars.ts`"]:::open
     1FD.30["`*1FD.30*<br/>types/corpus.ts`"]:::blocked
-    1FD.31["`*1FD.31*<br/>types/description.ts`"]:::open
+    1FD.31["`*1FD.31*<br/>types/description.ts`"]:::done
     1FD.32["`*1FD.32*<br/>types/visibility.ts`"]:::done
     1FD.33["`*1FD.33*<br/>types/save.ts`"]:::blocked
     1FD.34["`*1FD.34*<br/>Configure deno test`"]:::done
@@ -714,10 +714,10 @@ graph TD
     1FD.14 --> 1FD.15 & 1FD.16 & 1FD.17
     1FD.15 --> 1FD.30
     1FD.16 --> 1FD.30
-    1FD.17 --> 1FD.30
+    1FD.17 --> 1FD.30 & 1FD.31
     1FD.18 --> 1FD.19 & 1FD.20
     1FD.19 --> 1FD.21 & 1FD.24 & 1FD.29
-    1FD.20 --> 1FD.24 & 1FD.29
+    1FD.20 --> 1FD.24 & 1FD.29 & 1FD.31
     1FD.21 --> 1FD.23
     1FD.22 --> 1FD.27
     1FD.23 --> 1FD.22

--- a/src/lib/types/description.ts
+++ b/src/lib/types/description.ts
@@ -1,0 +1,168 @@
+/**
+ * Description generation and presentation type definitions (doc 05 §13, doc 04 §3.4) — Stage 9 of
+ * the pipeline, where the artefact meets the player. Templates generate register-parameterised
+ * prose from artefact properties; assembly orders the result by lens salience into the
+ * presentation the agent actually reads. Register scope is the three-value `DescriptionRegister`
+ * (lens.ts) throughout: doc 05 §13's code blocks predate the MVP narrowing and type these fields
+ * as the five-value `ObservationRegister`, which is post-MVP along with the `RegisterAccess`
+ * acquisition model (doc 12 §2.10, doc 13 §4). This module is data shapes only, no behaviour;
+ * generation lives under `engine/generation/` (roadmap 2GN.33–2GN.38).
+ */
+
+import type { CrossReference, DescriptionRegister } from './lens.ts';
+import type { ContextTag, FunctionTag } from './tags.ts';
+import type {
+	DatingConfidence,
+	DatingMethod,
+	DepositionType,
+	PreservationState,
+	SiteType,
+} from './world.ts';
+
+/**
+ * All prose variants for one describable property (doc 05 §13.1). This is where the Tracery-like
+ * grammar operates — at the prose level, not the structural level. Template data itself lives in
+ * `src/lib/data/descriptions/` per register (roadmap 2GN.35–2GN.37).
+ */
+export interface DescriptionTemplate {
+	/** The property these variants describe. */
+	property: string;
+
+	/** Candidate renderings across registers. */
+	variants: DescriptionVariant[];
+}
+
+/**
+ * One template rendering of a property (doc 05 §13.1). The lens selects among a property's
+ * variants by hypothesis alignment (doc 04 §3.4); the register system gates which variants are
+ * available at all.
+ */
+export interface DescriptionVariant {
+	/** Tracery-style template with slots. */
+	template: string;
+
+	/** Function tags this variant's framing foregrounds. */
+	emphasis: FunctionTag[];
+
+	/** Which register the variant belongs to (three-value MVP scope, doc 12 §2.10). */
+	register: DescriptionRegister;
+}
+
+/**
+ * The assembled description an agent reads when inspecting an artefact (doc 05 §13.2): ordered
+ * observations sorted by the lens's salience weighting, tag suggestions and primed
+ * cross-references. This is the lens-filtered subjective view — the same underlying artefact
+ * produces different presentations for agents with different interpretive models.
+ */
+export interface ArtefactPresentation {
+	/** The artefact being presented. */
+	artefactId: string;
+
+	/** Neutral physical description. */
+	label: string;
+
+	/** Player-visible find context. */
+	provenance: ProvenancePresentation;
+
+	/** High-salience observations, shown up front. */
+	primaryObservations: PresentedObservation[];
+
+	/** Low-salience observations — the "on closer inspection" section, requires investigation. */
+	secondaryObservations: PresentedObservation[];
+
+	/** Lens-weighted classification prompts (doc 04 §3.2). */
+	suggestedTags: TagSuggestion[];
+
+	/** Lens-primed comparisons with previously studied artefacts (doc 04 §3.3). */
+	crossReferences: CrossReference[];
+}
+
+/**
+ * One rendered observation within a presentation (doc 05 §13.2). The description text is the
+ * register- and lens-selected variant; the raw data behind it stays accessible on drill-down, so
+ * the lens shapes emphasis without ever hiding measurable fact (doc 04 §3.5).
+ */
+export interface PresentedObservation {
+	/** The property this observation renders. */
+	propertyId: string;
+
+	/** Register + lens selected variant text. */
+	description: string;
+
+	/** Lens-weighted prominence (doc 04 §3.1) — determines primary/secondary placement. */
+	salience: number;
+
+	/** Register the text was rendered in (three-value MVP scope, doc 12 §2.10). */
+	register: DescriptionRegister;
+
+	/** Underlying measurements, always accessible on drill-down. */
+	rawData: Map<string, string | number>;
+}
+
+/**
+ * One tag suggestion within a presentation (doc 05 §13.2), pairing the engine's ground truth with
+ * the lens-boosted score the agent actually sees. The gap between the two is where confirmation
+ * bias lives.
+ */
+export interface TagSuggestion {
+	/** The tag being suggested. */
+	tag: FunctionTag | ContextTag;
+
+	/** Visibility: occluded — engine use only. Plausibility from properties alone. */
+	groundTruthScore: number;
+
+	/** Boost from the agent's interpretive model (doc 04 §3.2). */
+	lensBoost: number;
+
+	/** What the agent sees. */
+	presentedScore: number;
+
+	/** Which beliefs are boosting this suggestion. */
+	sourceHypotheses: string[];
+}
+
+/**
+ * Provisional, not doc-specified: named by `ArtefactPresentation.provenance` (doc 05 §13.2) but
+ * never shaped. The player-visible projection of world.ts `Provenance` (doc 05 §3.5): the site
+ * and context groups are observable, while `cultureId`, `phaseId` and `year` are occluded and
+ * deliberately absent — absolute dating is not free information (doc 05 §4.7); relative dating
+ * via stratigraphy is. Expect this to firm up when `generateDescription` lands (roadmap 2GN.38).
+ */
+export interface ProvenancePresentation {
+	/** Site name, as recorded at excavation. */
+	siteName: string;
+
+	/** Kind of site (doc 05 §3.5). */
+	siteType: SiteType;
+
+	/** Broad geographic region the site sits within. */
+	region: string;
+
+	/** Stratigraphic layer identifier — relative dating comes free from stratigraphy (doc 05 §4.7). */
+	layer: string;
+
+	/** Ids of other artefacts recovered in direct association. */
+	associatedFinds: string[];
+
+	/** How well the artefact survived to excavation. */
+	condition: PreservationState;
+
+	/** How the artefact came to be deposited (doc 05 §3.5). */
+	deposition: DepositionType;
+
+	/**
+	 * Corpus-derived dated range for the layer, present only when an NPC `DatingFramework`
+	 * (world.ts, doc 05 §4.7) covers the site. Presented as established fact in the reference
+	 * literature — and possibly wrong. Absent when no framework covers the layer.
+	 */
+	dating?: {
+		/** Estimated absolute year range, mirroring `LayerDating.estimatedRange`. */
+		estimatedRange: [number, number];
+
+		/** How the range was derived (doc 05 §4.7). */
+		method: DatingMethod;
+
+		/** How settled the source framework is in the literature (doc 05 §4.7). */
+		confidence: DatingConfidence;
+	};
+}

--- a/src/lib/types/interpretation.ts
+++ b/src/lib/types/interpretation.ts
@@ -13,6 +13,7 @@
  * and the player store's `id`-keyed, `status`-filtered `Map` usage (doc 08 §3.4).
  */
 
+import type { DescriptionRegister } from './lens.ts';
 import type { ContextTag, FunctionTag, MaterialTag } from './tags.ts';
 
 /**
@@ -106,17 +107,9 @@ export interface Observation {
 	 * technical-register and interpretive-mode.
 	 *
 	 * MVP note: this is the three-value `DescriptionRegister` from doc 04 §3.4, not the post-MVP
-	 * five-register `ObservationRegister` model from doc 05 §12 (doc 06 §2.1, doc 13). Typed
-	 * inline for now because `DescriptionRegister` doesn't exist yet.
-	 *
-	 * TODO: replace this inline union with an import of `DescriptionRegister` from `./lens.ts`
-	 * (roadmap 1FD.20) or `./description.ts` (roadmap 1FD.31), whichever lands first, once either
-	 * exists.
+	 * five-register `ObservationRegister` model from doc 05 §12 (doc 06 §2.1, doc 13).
 	 */
-	observationRegister?:
-		| 'observational'
-		| 'interpretive'
-		| 'technical';
+	observationRegister?: DescriptionRegister;
 
 	/** Term index when the observation was first recorded. */
 	createdAtTerm: number;

--- a/src/lib/types/lens.ts
+++ b/src/lib/types/lens.ts
@@ -1,0 +1,235 @@
+/**
+ * Interpretive lens type definitions (doc 04) — the core mechanic's five channels and the
+ * per-hypothesis strength model that scales them. The lens filters what an agent notices, never
+ * what exists: it operates exclusively on observable and inferable properties
+ * (`PropertyVisibility`, visibility.ts), reordering, reframing and de-emphasising without ever
+ * revealing an occluded property or hiding an observable one. Channel outputs
+ * (`ObservationSalience`, `ClassificationSuggestion`, `CrossReference`, `DescriptionFrame`,
+ * `OmissionCheck`) are computed per artefact on inspection; `LensStrength` and `LensState` are
+ * agent-level. All of it is agent-generic (doc 11 §2.6) — the player's lens and an NPC scholar's
+ * lens are the same shapes. This module is data shapes only, no behaviour; lens computation lives
+ * under `engine/lens/` (roadmap 6LS.*).
+ */
+
+import type { ContextTag, FunctionTag } from './tags.ts';
+
+/**
+ * Channel 1, observation salience (doc 04 §3.1): the lens-weighted prominence of one observable
+ * property in an artefact's inspection list. The list is sorted by `finalWeight` descending;
+ * properties below a threshold (e.g. 0.5) drop into an "on closer inspection" section that costs
+ * an extra action. What the player notices first shapes the hypothesis they form.
+ */
+export interface ObservationSalience {
+	/** The property whose prominence this describes. */
+	propertyId: string;
+
+	/** Default prominence with no lens influence (1.0 = neutral). */
+	baseWeight: number;
+
+	/** Per-hypothesis adjustments, kept individually for traceability. */
+	lensAdjustments: Array<{
+		/** The hypothesis contributing this adjustment. */
+		sourceHypothesisId: string;
+
+		/** Signed adjustment from the hypothesis. */
+		weightDelta: number;
+
+		/** Traceable rationale, e.g. `"hypothesis h3 infers decorative obsidian"`. */
+		reason: string;
+	}>;
+
+	/** Computed: base + sum(adjustments), clamped [0.1, 3.0]. */
+	finalWeight: number;
+}
+
+/**
+ * Channel 2, classification suggestions (doc 04 §3.2): one pre-populated classification option,
+ * weighted toward consistency with the agent's existing hypotheses. The agent can always choose
+ * any classification — the gravity is in the ordering and prominence, not the option set.
+ */
+export interface ClassificationSuggestion {
+	/** The classification being suggested. */
+	classificationId: string;
+
+	/** Player-facing label for the classification. */
+	label: string;
+
+	/** Plausibility from artefact properties alone. */
+	basePlausibility: number;
+
+	/** Boost from interpretive-model alignment. */
+	lensBoost: number;
+
+	/** Computed: `basePlausibility * (1 + lensBoost)`. */
+	finalScore: number;
+
+	/** Which beliefs are boosting this suggestion. */
+	sourceHypotheses: string[];
+}
+
+/**
+ * Channel 3, cross-reference priming (doc 04 §3.3): a suggested comparison with a previously
+ * studied artefact. Matching is biased — properties aligning with existing hypotheses generate
+ * stronger signals, so the system can truthfully cluster artefacts in ways that reinforce a wrong
+ * assumption (a river find promoted as "Culture A" because the agent believes Culture A is
+ * river-dwelling).
+ */
+export interface CrossReference {
+	/** The previously studied artefact being surfaced. */
+	targetArtefactId: string;
+
+	/** Properties the two artefacts share. */
+	matchingProperties: string[];
+
+	/** Property overlap score, lens-free. */
+	baseRelevance: number;
+
+	/** Hypothesis-aligned boost. */
+	lensRelevance: number;
+
+	/** Computed: `baseRelevance * (1 + lensRelevance)`. */
+	finalRelevance: number;
+
+	/** Flag for contradiction detection (doc 06): the match may cluster across true cultures. */
+	potentiallyMisleading: boolean;
+}
+
+/**
+ * The three MVP description registers (doc 04 §3.4): equally truthful framings of the same
+ * physical reality. Observational foregrounds material-science language, interpretive foregrounds
+ * function and meaning, technical foregrounds craft process. MVP-canonical per doc 12 §2.10; the
+ * five-value `ObservationRegister` + `RegisterAccess` acquisition model (doc 05 §12) is post-MVP
+ * (doc 13 §4).
+ */
+export type DescriptionRegister =
+	| 'observational'
+	| 'interpretive'
+	| 'technical';
+
+/**
+ * Channel 4, descriptive framing (doc 04 §3.4): register-parameterised description variants for
+ * one property, with the lens's selection recorded. The lens controls emphasis and ordering, not
+ * availability — the other registers stay accessible through deliberate investigation, and within
+ * a register the lens selects the variant that aligns with the agent's framework.
+ */
+export interface DescriptionFrame {
+	/** The property being described. */
+	propertyId: string;
+
+	/** Candidate variants per register, all describing the same physical reality. */
+	registers: Record<
+		DescriptionRegister,
+		Array<{
+			/** The rendered description text. */
+			text: string;
+
+			/** What this variant foregrounds. */
+			emphasis: string;
+
+			/** Which hypothesis tags this variant supports. */
+			alignsWithTags: string[];
+		}>
+	>;
+
+	/** Register the lens foregrounded, based on lens alignment. */
+	selectedRegister: DescriptionRegister;
+
+	/** Index of the chosen variant within the selected register. */
+	selectedVariant: number;
+}
+
+/**
+ * Channel 5, omission blindness (doc 04 §3.5): the inverse of salience. Properties that
+ * contradict existing beliefs are not hidden, only harder to notice — placed lower, described
+ * more neutrally, never flagged as noteworthy. `suppressionLevel` is capped so significant
+ * contradictions still bubble up: iron rivets can slip past, a full iron sword from a
+ * "no metalwork" culture cannot.
+ */
+export interface OmissionCheck {
+	/** The property whose suppression this describes. */
+	propertyId: string;
+
+	/** Hypothesis ids this property conflicts with. */
+	contradicts: string[];
+
+	/** 0 = no suppression, 1 = maximum de-emphasis (capped in practice). */
+	suppressionLevel: number;
+
+	/** Visibility from property importance, lens-free. */
+	baseVisibility: number;
+
+	/** Computed: `baseVisibility * (1 - suppressionLevel * 0.6)`. */
+	adjustedVisibility: number;
+}
+
+/**
+ * Per-hypothesis lens strength (doc 04 §4): how much one belief warps perception, scaling with
+ * the agent's commitment to it. A published, taught, cited, well-evidenced hypothesis filters
+ * hard; a tentative unsupported one has almost no effect. Recomputed at term boundaries with
+ * decay applied (doc 04 §4.1, roadmap 6LS.4).
+ */
+export interface LensStrength {
+	/** The hypothesis this strength belongs to. */
+	hypothesisId: string;
+
+	/** The individual contributions, kept for legibility and the Explorer (roadmap 6LS.16). */
+	factors: {
+		/**
+		 * Graduated by dissemination state (doc 10, doc 12 §2.16): 0 (private), 0.1 (circulated),
+		 * 0.15 (presented), 0.2 (submitted), 0.3 (published), 0.35 (collected).
+		 */
+		dissemination: number;
+
+		/** 0–1, multiplied with `dissemination` — high-prestige publication is stronger lock-in. */
+		venuePrestige: number;
+
+		/** 0–1 direct mapping from hypothesis confidence. */
+		confidence: number;
+
+		/** `log2(count) * 0.1`, capped at 0.3. */
+		evidenceCount: number;
+
+		/** +0.2 if true (career activity: student supervision, doc 07). */
+		taught: boolean;
+
+		/** 0.05 per citation, capped at 0.2. */
+		cited: number;
+
+		/** -0.1 per active contradiction. */
+		contradictions: number;
+
+		/** -0.15 if true — sabbatical grants temporary clarity (doc 07 §4.1). */
+		onSabbatical: boolean;
+	};
+
+	/** Combined strength, clamped [0, 1]. */
+	totalStrength: number;
+
+	/** Term index when strength was last computed. */
+	lastRecalculatedTerm: number;
+}
+
+/**
+ * Provisional, not doc-specified: the agent-level lens summary. Named throughout the docs
+ * (doc 06 §6's `lensState` field, doc 08 §3.3's derived store) but never given a shape; authored
+ * here against its consumers — the five channel functions (roadmap 6LS.6–6LS.10) take
+ * `(artefact, lensState)` rather than the `InterpretiveModel`, so this must carry everything they
+ * need. The per-artefact channel outputs above are deliberately excluded: they are computed on
+ * demand, not cached agent-level. Never persisted — recomputed from the interpretive model on
+ * load (doc 12 §2.14). Expect this to firm up when `computeLens` lands (roadmap 6LS.2, 6LS.3).
+ */
+export interface LensState {
+	/** Per-hypothesis computed strength, keyed by hypothesis id (doc 04 §4). */
+	strengths: Map<string, LensStrength>;
+
+	/**
+	 * Provisional: aggregated per-tag boost/suppression, 0 = neutral, matching the
+	 * `(1 + lensBoost)` channel arithmetic (doc 04 §3.2). Each hypothesis contributes boosts for
+	 * its tags scaled by its strength (roadmap 6LS.3) — this is what lets channel functions run on
+	 * `LensState` alone.
+	 */
+	tagWeights: Map<FunctionTag | ContextTag, number>;
+
+	/** Term index when this state was computed — recompute/decay bookkeeping (doc 04 §4.1). */
+	computedAtTerm: number;
+}

--- a/src/lib/types/term.test.ts
+++ b/src/lib/types/term.test.ts
@@ -1,0 +1,56 @@
+/// <reference lib="deno.ns" />
+import { assertEquals } from '@std/assert';
+import {
+	termIndexFromWeek,
+	termStartWeek,
+	weekInTerm,
+	WEEKS_PER_YEAR,
+	yearFromTerm,
+} from './term.ts';
+
+Deno.test('constants: a year models 48 weeks', () => {
+	assertEquals(WEEKS_PER_YEAR, 48);
+});
+
+Deno.test('termStartWeek: term N starts at week N * 12', () => {
+	assertEquals(termStartWeek(0), 0);
+	assertEquals(termStartWeek(1), 12);
+	assertEquals(termStartWeek(4), 48); // First term of year 1
+});
+
+Deno.test('weekInTerm: wraps to 0-based within-term position at term boundaries', () => {
+	assertEquals(weekInTerm(0), 0);
+	assertEquals(weekInTerm(11), 11); // Last week of term 0
+	assertEquals(weekInTerm(12), 0); // First week of term 1
+	assertEquals(weekInTerm(25), 1);
+});
+
+Deno.test('termIndexFromWeek: advances at 12-week boundaries', () => {
+	assertEquals(termIndexFromWeek(0), 0);
+	assertEquals(termIndexFromWeek(11), 0);
+	assertEquals(termIndexFromWeek(12), 1);
+	assertEquals(termIndexFromWeek(47), 3); // Last week of year 0
+	assertEquals(termIndexFromWeek(48), 4); // First week of year 1
+});
+
+Deno.test('yearFromTerm: advances every 4 terms', () => {
+	assertEquals(yearFromTerm(0), 0);
+	assertEquals(yearFromTerm(3), 0);
+	assertEquals(yearFromTerm(4), 1);
+	assertEquals(yearFromTerm(8), 2);
+});
+
+Deno.test('helpers: term index round-trips through its start week', () => {
+	for (const termIndex of [0, 1, 3, 4, 17]) {
+		assertEquals(termIndexFromWeek(termStartWeek(termIndex)), termIndex);
+	}
+});
+
+Deno.test('helpers: absolute week decomposes into term start plus within-term offset', () => {
+	for (const absoluteWeek of [0, 5, 11, 12, 47, 48, 100]) {
+		assertEquals(
+			termStartWeek(termIndexFromWeek(absoluteWeek)) + weekInTerm(absoluteWeek),
+			absoluteWeek,
+		);
+	}
+});

--- a/src/lib/types/term.ts
+++ b/src/lib/types/term.ts
@@ -1,0 +1,149 @@
+/**
+ * Time and action economy type definitions (doc 08 §3.6, doc 11 §2.8). Discrete academic terms
+ * with concurrent actions consuming both time and energy from a single continuum: the `termState`
+ * store (roadmap 3WS.*) tracks within-term resources, the orchestrator handles term boundaries.
+ * Doc 08 §3.6 is authoritative here — it supersedes the older `TermState`/`BackgroundDrain`
+ * sketches in doc 07 (doc 12 §2.9).
+ *
+ * Unlike its siblings this module is not shapes-only: doc 08 §3.6 defines the week/term constants
+ * and four derived-position helpers alongside the types, and they live here with them. Anything
+ * beyond that stays out — in particular `getTermType(termIndex)` belongs to career progression
+ * (roadmap 9CR.20, `engine/career/progression.ts`), not this file.
+ */
+
+/**
+ * The four term types of an academic year (doc 08 §3.6). `summer-research` is the strategically
+ * distinct season: it carries no teaching background drain, so the player plans their year around
+ * it for fieldwork, uninterrupted writing and conference attendance.
+ */
+export type TermType =
+	| 'autumn'
+	| 'spring'
+	| 'summer-teaching'
+	| 'summer-research';
+
+/**
+ * One year of the academic calendar (doc 08 §3.6): four terms of `WEEKS_PER_TERM` weeks each,
+ * giving `WEEKS_PER_YEAR` modelled weeks — the remaining 4 weeks of a calendar year are implicit
+ * transition/holiday, never modelled.
+ */
+export interface AcademicYear {
+	/** 0-based year index within the career. */
+	yearIndex: number;
+
+	/** The year's term cycle. Default: `['autumn', 'spring', 'summer-teaching', 'summer-research']`. */
+	terms: [TermType, TermType, TermType, TermType];
+}
+
+/** Modelled weeks per term (doc 08 §3.6, doc 11 §2.8). */
+export const WEEKS_PER_TERM = 12;
+
+/** Terms per academic year (doc 08 §3.6, doc 11 §2.8). */
+export const TERMS_PER_YEAR = 4;
+
+/** Modelled weeks per year — 48; the other 4 are implicit transition, never modelled (doc 08 §3.6). */
+export const WEEKS_PER_YEAR = WEEKS_PER_TERM * TERMS_PER_YEAR;
+
+/**
+ * Within-term resource state (doc 08 §3.6). Actions consume weeks and energy from this single
+ * budget; when either is exhausted, the term ends and the orchestrator runs the term-boundary
+ * sequence (dissemination resolution, strain accumulation, lens decay, career checks).
+ */
+export interface TermState {
+	/** 0-based term index across the whole career (`yearFromTerm` derives the year). */
+	currentTermIndex: number;
+
+	/**
+	 * Canonical timestamp — 0-based, never resets, spans the entire career (doc 11 §2.8).
+	 * Background processes (peer review, dissemination lead times, reputational lag) run on
+	 * absolute weeks, so work naturally spans term boundaries; within-term position is derived on
+	 * demand via `weekInTerm`.
+	 */
+	currentAbsoluteWeek: number;
+
+	/** Which term type this is — determines which background drains apply. */
+	termType: TermType;
+
+	/** Weeks available this term. Usually `WEEKS_PER_TERM`; special circumstances may modify it. */
+	weekCapacity: number;
+
+	/** Sum of activity durations scheduled this term. */
+	weeksAllocated: number;
+
+	/** Total energy for this term (may include carry-over). */
+	energyBudget: number;
+
+	/** Remaining energy, decremented by actions. */
+	energyRemaining: number;
+
+	/** Ongoing commitments — the subset whose `activeTermTypes` includes `termType` applies. */
+	backgroundDrains: BackgroundDrain[];
+
+	/** Record of what was done this term. */
+	completedActions: CompletedAction[];
+}
+
+/**
+ * An ongoing commitment that drains energy at term start (doc 08 §3.6). Term-conditional:
+ * teaching load applies to autumn, spring and summer-teaching but not summer-research, while
+ * admin or editorial duties might apply year-round. Evaluated when calculating the term's
+ * effective energy budget.
+ */
+export interface BackgroundDrain {
+	/** What the drain is, e.g. `"teaching-load"`, `"supervision"`, `"admin"`, `"editorial"`. */
+	source: string;
+
+	/** Energy cost applied each term the drain is active. */
+	energyCostPerTerm: number;
+
+	/** Which term types this drain applies to. */
+	activeTermTypes: TermType[];
+
+	/** Player-facing description of the commitment. */
+	description: string;
+}
+
+/**
+ * Record of one completed action (doc 08 §3.6). Durations are in weeks; an action's span is
+ * anchored to the absolute week counter, so it may cross term boundaries even though it is
+ * recorded against the term it was initiated in.
+ */
+export interface CompletedAction {
+	/** What kind of action was taken. */
+	actionType: string;
+
+	/** Energy the action consumed. */
+	energyCost: number;
+
+	/** How many weeks the action spanned. */
+	durationWeeks: number;
+
+	/** Absolute week the action started — may span term boundaries. */
+	startWeek: number;
+
+	/** Term in which the action was initiated. */
+	termIndex: number;
+}
+
+/**
+ * Absolute week a term starts on (doc 08 §3.6). Derived, not stored: term N starts at week
+ * N × `WEEKS_PER_TERM`, matching how the orchestrator seeds the next term's counter.
+ */
+export function termStartWeek(termIndex: number): number {
+	return termIndex * WEEKS_PER_TERM;
+}
+
+/** 0-based position of an absolute week within its term (doc 08 §3.6). Derived, not stored. */
+export function weekInTerm(absoluteWeek: number): number {
+	return absoluteWeek % WEEKS_PER_TERM;
+}
+
+/** 0-based term index an absolute week falls in (doc 08 §3.6). Derived, not stored. */
+export function termIndexFromWeek(absoluteWeek: number): number {
+	return Math.floor(absoluteWeek / WEEKS_PER_TERM);
+}
+
+/** 0-based academic year a term index falls in (doc 08 §3.6). Derived, not stored. */
+export function yearFromTerm(termIndex: number): number {
+	return Math.floor(termIndex / TERMS_PER_YEAR);
+}

--- a/src/lib/types/world.ts
+++ b/src/lib/types/world.ts
@@ -481,3 +481,68 @@ export interface GeologicalContext {
 	/** Availability keyed by material id. */
 	materialAvailability: Map<string, RegionalAvailability>;
 }
+
+/**
+ * How a layer's estimated date range was derived (doc 05 §4.7). The first two are inference from
+ * context; the last three are scientific analyses the player can commission once career-gated
+ * access allows (they take time, may consume part of the artefact and carry error margins).
+ */
+export type DatingMethod =
+	| 'stratigraphic-inference' // Relative position + anchored layers
+	| 'typological-comparison' // Compared to dated artefacts elsewhere
+	| 'radiocarbon' // C14 (requires organic material)
+	| 'dendrochronology' // Tree rings (requires preserved wood)
+	| 'thermoluminescence'; // TL (requires fired ceramics)
+
+/**
+ * How settled a site's dating framework is within the professional corpus (doc 05 §4.7). Hoisted
+ * from the doc's inline union on `DatingFramework.confidence` so the vocabulary stays centralised
+ * (the `ClaimStatus` precedent in interpretation.ts) — description presentation (roadmap 1FD.31)
+ * is the second consumer.
+ */
+export type DatingConfidence =
+	| 'well-established'
+	| 'provisional'
+	| 'contested';
+
+/**
+ * The corpus's dated estimate for one stratigraphic layer (doc 05 §4.7). This is an NPC claim
+ * about the world, not ground truth: the true deposition year lives on `Provenance.year`
+ * (occluded), and `estimatedRange` may fail to contain it when the original dating was flawed or
+ * extrapolated beyond its evidence base.
+ */
+export interface LayerDating {
+	/** Stratigraphic layer identifier, matching `Provenance.context.layer`. */
+	layerId: string;
+
+	/** Estimated absolute year range for the layer. */
+	estimatedRange: [number, number];
+
+	/** How the range was derived. */
+	method: DatingMethod;
+
+	/** Years of uncertainty either side of the range. */
+	errorMargin: number;
+}
+
+/**
+ * An approximate chronological framework for a well-studied site, established by NPC dating work
+ * (doc 05 §4.7). Presented as established fact in the reference literature — and possibly wrong.
+ * Visibility: observable via the corpus, but observable-as-claim: an artefact's true age is
+ * `WorldChronology.presentYear - Provenance.year` and stays hidden; the player earns absolute
+ * dates through frameworks like this or by commissioning independent dating. Overturning a
+ * framework is a high-magnitude, high-scrutiny claim (doc 05 §4.6).
+ */
+export interface DatingFramework {
+	/** Site this framework covers (`Provenance.site`). */
+	siteId: string;
+
+	/** Per-layer dated estimates. */
+	layers: LayerDating[];
+
+	/** Ids of the NPC publications that established the framework. */
+	establishedBy: string[];
+
+	/** How settled the framework is in the literature. */
+	confidence: DatingConfidence;
+}


### PR DESCRIPTION
# Foundation Types: Dating, Terms, Lens and Description

## Overview

Completes the last four open Milestone 1 type tasks (1FD.17, 1FD.20, 1FD.28, 1FD.31). Every remaining Foundation type file now exists: dating frameworks join `world.ts`, while `term.ts`, `lens.ts` and `description.ts` are new. Two types the design docs name but never shape (`LensState`, `ProvenancePresentation`) land as flagged provisional designs. One deliberate deviation: `DescriptionRegister` lives in `lens.ts` rather than `description.ts`, keeping imports one-directional; the roadmap annotation records the move.

## Summary

An archaeology department takes delivery of its remaining office furniture: a wall calendar that refuses to acknowledge holidays, a set of tinted spectacles that get stronger every time the wearer publishes, a label printer for museum placards and a filing cabinet of confidently wrong carbon-dating certificates. Nobody has moved in yet. The furniture is the point.

> [!TIP]
> Nothing to do after pulling. `deno task test` picks up seven new tests from `term.test.ts` automatically.

---

## Changes

<details>
<summary><code>src/lib/types/world.ts</code>: dating frameworks (1FD.17)</summary>

- `DatingMethod`, `DatingConfidence`, `LayerDating`, `DatingFramework` per doc 05 §4.7
- `DatingConfidence` is hoisted from the doc's inline union so `description.ts` can reuse it
</details>

<details>
<summary><code>src/lib/types/term.ts</code> + <code>term.test.ts</code>: academic calendar (1FD.28)</summary>

- `TermType`, `AcademicYear`, `TermState`, `BackgroundDrain`, `CompletedAction` per doc 08 §3.6
- Constants `WEEKS_PER_TERM`, `TERMS_PER_YEAR`, `WEEKS_PER_YEAR` and the four week/term position helpers, all 0-based
- First test file alongside a type module; covers boundaries and round-trip identities
</details>

<details>
<summary><code>src/lib/types/lens.ts</code>: the five channels (1FD.20)</summary>

- `ObservationSalience`, `ClassificationSuggestion`, `CrossReference`, `DescriptionFrame`, `OmissionCheck`, `LensStrength` per doc 04 §3 and §4, including the graduated dissemination factor with 0.15 for presented
- `DescriptionRegister` lands here: doc 04 §3.4 defines it and `DescriptionFrame` keys a `Record` on it
- `LensState` is provisional. The docs name it but never shape it. Per-hypothesis strengths, aggregated tag weights, recompute bookkeeping. Firms up at 6LS.2/6LS.3.
- `interpretation.ts` swaps its inline register union for the import, resolving the 1FD.18 TODO. Value-identical.
</details>

<details>
<summary><code>src/lib/types/description.ts</code>: presentation layer (1FD.31)</summary>

- `DescriptionTemplate`, `DescriptionVariant`, `ArtefactPresentation`, `PresentedObservation`, `TagSuggestion` per doc 05 §13
- Both `register` fields narrowed to the three-value MVP scope (doc 12 §2.10)
- `ProvenancePresentation` is provisional: the player-visible slice of `Provenance`, with `cultureId`, `phaseId` and `year` deliberately absent. Firms up at 2GN.38.
</details>

<details>
<summary><code>docs/roadmaps/mvp.md</code>: bookkeeping</summary>

- Four tasks ticked with completion annotations; the 1FD.31 note records the `DescriptionRegister` move
- FD next-up row becomes 1FD.21, 1FD.24, 1FD.29, 1FD.36; 1FD.24 and 1FD.29 flip from blocked to open
- New graph edges `1FD.17 --> 1FD.31` and `1FD.20 --> 1FD.31` record the imports `description.ts` introduced
</details>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new data structures for descriptions, lenses, terms, and world dating.
  * Expanded support for presenting artefacts with provenance, observations, tag suggestions, and confidence details.
  * Introduced academic-term helpers and state tracking for time-based calculations.

* **Bug Fixes**
  * Aligned observation register typing across the app for more consistent data handling.

* **Tests**
  * Added coverage for term/week calculation behavior and boundary cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->