### PR TITLE
Add Venue, Contradiction and Scholar Types

### DIFF
--- a/docs/roadmaps/mvp.md
+++ b/docs/roadmaps/mvp.md
@@ -6,7 +6,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 |          | Status                  | Next Up           | Blocked           |
 | -------- | ----------------------- | ----------------- | ----------------- |
-| **FD**   | In progress             | 1FD.23, 1FD.24, 1FD.29, 1FD.36 | — |
+| **FD**   | In progress             | 1FD.24, 1FD.29, 1FD.36 | — |
 | **GN**   | Not started             | 2GN.1, 2GN.2, 2GN.17, 2GN.22 | —      |
 | **WS**   | Not started             | —                 | 2GN.56            |
 | **UI**   | Not started             | —                 | 3WS.15            |
@@ -52,7 +52,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 - [x] 1FD.21. `src/lib/types/documents.ts` — `DocumentNode`, `DocumentLineage`, `DerivationType`, `DerivationEvent`, `DocumentScope`, `Audience`, `PublicationRegister`, `DocumentPerception` (simplified MVP shape per doc 10 §11: `audienceReach`, `takeawayDivergence`, `citationCount`; `DocumentNode` unavoidably references `DisseminationState`, so 1FD.22's full member list landed alongside it too)
 - [x] 1FD.22. `src/lib/types/documents.ts` — `DisseminationState`, `DisseminationEvent`, `DisseminationDetails`, `PeerReviewState`, `Retraction`, `TaintedLineage` (`DisseminationState` scoped to MVP's four states per doc 10 §11 — `presented`/`collected` deferred; completed alongside 1FD.21 since `DocumentNode` depends on it directly)
-- [ ] 1FD.23. `src/lib/types/venues.ts` — `VenueDefinition`, `ContainerModel`, `TemporalMode`, `SubmissionWindow`, `EditorialProcess`, `AudienceEncounter`, `VenueScope`, `VenueClassification`
+- [x] 1FD.23. `src/lib/types/venues.ts` — `VenueDefinition`, `ContainerModel`, `TemporalMode`, `SubmissionWindow`, `EditorialProcess`, `AudienceEncounter`, `VenueScope`, `VenueClassification` (doc 07 §3.1 transcribed verbatim, term-denominated; doc 10 §6.4's week-denominated `VenueTemporalProfile` overlaps it and is owned by no roadmap task — unreconciled in doc 12)
 - [ ] 1FD.24. `src/lib/types/contradiction.ts` — `Contradiction` union, `MaterialContradiction`, `TemporalContradiction`, `CulturalContradiction`, `StructuralContradiction`, `ProvenanceContradiction`, `CorpusContradiction`, `RarityContradiction`, `MaterialProvenanceContradiction` (all eight members per doc 06 §4.2; `CulturalContradiction.agentClaim` references a claimId at MVP — doc 06's profileId applies once cultural-profile documents land post-MVP)
 - [ ] 1FD.25. `src/lib/types/contradiction.ts` — `ContradictionSeverity`, `ContradictionQueue`, `QueuedContradiction`, `DiegeticSurface`, `Resolution`, `HypothesisStrain` (resolves the two cross-file `TODO(1FD.25)` stand-ins in `interpretation.ts`)
 - [ ] 1FD.27. `src/lib/types/career.ts` — `RoleRequirement`, `DisseminationCareerEffect`, `PeerReviewCareerEvent`, `ReviewerFeedback`
@@ -686,7 +686,7 @@ graph TD
     1FD.20["`*1FD.20*<br/>types/lens.ts`"]:::done
     1FD.21["`*1FD.21*<br/>types/documents core`"]:::done
     1FD.22["`*1FD.22*<br/>types/documents dissem`"]:::done
-    1FD.23["`*1FD.23*<br/>types/venues.ts`"]:::open
+    1FD.23["`*1FD.23*<br/>types/venues.ts`"]:::done
     1FD.24["`*1FD.24*<br/>types/contradiction core`"]:::open
     1FD.25["`*1FD.25*<br/>types/contradiction queue`"]:::blocked
     1FD.26["`*1FD.26*<br/>types/career core`"]:::done

--- a/docs/roadmaps/mvp.md
+++ b/docs/roadmaps/mvp.md
@@ -6,7 +6,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 |          | Status                  | Next Up           | Blocked           |
 | -------- | ----------------------- | ----------------- | ----------------- |
-| **FD**   | In progress             | 1FD.24, 1FD.29, 1FD.36 | — |
+| **FD**   | In progress             | 1FD.24, 1FD.29, 1FD.36, 1FD.40 | — |
 | **GN**   | Not started             | 2GN.1, 2GN.2, 2GN.17, 2GN.22 | —      |
 | **WS**   | Not started             | —                 | 2GN.56            |
 | **UI**   | Not started             | —                 | 3WS.15            |
@@ -52,13 +52,14 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 - [x] 1FD.21. `src/lib/types/documents.ts` — `DocumentNode`, `DocumentLineage`, `DerivationType`, `DerivationEvent`, `DocumentScope`, `Audience`, `PublicationRegister`, `DocumentPerception` (simplified MVP shape per doc 10 §11: `audienceReach`, `takeawayDivergence`, `citationCount`; `DocumentNode` unavoidably references `DisseminationState`, so 1FD.22's full member list landed alongside it too)
 - [x] 1FD.22. `src/lib/types/documents.ts` — `DisseminationState`, `DisseminationEvent`, `DisseminationDetails`, `PeerReviewState`, `Retraction`, `TaintedLineage` (`DisseminationState` scoped to MVP's four states per doc 10 §11 — `presented`/`collected` deferred; completed alongside 1FD.21 since `DocumentNode` depends on it directly)
-- [x] 1FD.23. `src/lib/types/venues.ts` — `VenueDefinition`, `ContainerModel`, `TemporalMode`, `SubmissionWindow`, `EditorialProcess`, `AudienceEncounter`, `VenueScope`, `VenueClassification` (doc 07 §3.1 transcribed verbatim, term-denominated; doc 10 §6.4's week-denominated `VenueTemporalProfile` overlaps it and is owned by no roadmap task — unreconciled in doc 12)
+- [x] 1FD.23. `src/lib/types/venues.ts` — `VenueDefinition`, `ContainerModel`, `TemporalMode`, `SubmissionWindow`, `EditorialProcess`, `AudienceEncounter`, `VenueScope`, `VenueClassification` (doc 07 §3.1 transcribed verbatim, term-denominated; doc 10 §6.4's week-denominated `VenueTemporalProfile` overlaps it — reconciliation owned by 1FD.40)
 - [ ] 1FD.24. `src/lib/types/contradiction.ts` — `Contradiction` union, `MaterialContradiction`, `TemporalContradiction`, `CulturalContradiction`, `StructuralContradiction`, `ProvenanceContradiction`, `CorpusContradiction`, `RarityContradiction`, `MaterialProvenanceContradiction` (all eight members per doc 06 §4.2; `CulturalContradiction.agentClaim` references a claimId at MVP — doc 06's profileId applies once cultural-profile documents land post-MVP)
 - [ ] 1FD.25. `src/lib/types/contradiction.ts` — `ContradictionSeverity`, `ContradictionQueue`, `QueuedContradiction`, `DiegeticSurface`, `Resolution`, `HypothesisStrain` (resolves the two cross-file `TODO(1FD.25)` stand-ins in `interpretation.ts`)
 - [ ] 1FD.27. `src/lib/types/career.ts` — `RoleRequirement`, `DisseminationCareerEffect`, `PeerReviewCareerEvent`, `ReviewerFeedback`
 - [ ] 1FD.29. `src/lib/types/scholars.ts` — `MinimalScholar`, `NPCScholarSeed`, `SimulatedExcavation`
 - [ ] 1FD.30. `src/lib/types/corpus.ts` — `ProfessionalCorpus`, `FrequencyRecord`, `ContextFrequency`, `ConsensusStatement`, `Debate`, `DebatePosition`, `CoverageBudget`
 - [ ] 1FD.33. `src/lib/types/save.ts` — `SaveFile`, `SerialisedWorldState`, `SerialisedInterpretiveModel`, `SerialisedTermState`, `CURRENT_SAVE_VERSION`
+- [ ] 1FD.40. `src/lib/types/venues.ts` — `VenueTemporalProfile` (doc 10 §6.4, week-denominated: `submissionMode`, `openWeeks`, `cycleLengthWeeks`, `reviewLeadTimeWeeks`, `publicationLeadTimeWeeks`); reconcile with doc 07 §3.1's term-denominated `TemporalMode`/`SubmissionWindow` (supersede or coexist — doc 12's week-conversion sweep suggests weeks are canonical, cf. §2.9 precedent) and record the resolution in doc 12; consumed downstream by 9CR.5 (venue generation sets temporal properties) and 9CR.22 (venue cycles at term boundaries) — **depends on 1FD.23**
 
 **Project Explorer shell**
 
@@ -703,6 +704,7 @@ graph TD
     1FD.37["`*1FD.37*<br/>Explorer seed input`"]:::blocked
     1FD.38["`*1FD.38*<br/>Explorer PRNG display`"]:::blocked
     1FD.39["`*1FD.39*<br/>Explorer type index`"]:::blocked
+    1FD.40["`*1FD.40*<br/>types/venues temporal`"]:::open
     1FD.6 --> 1FD.7 & 1FD.8 & 1FD.9
     1FD.7 --> m1D
     1FD.8 --> m1D
@@ -721,6 +723,7 @@ graph TD
     1FD.21 --> 1FD.23
     1FD.22 --> 1FD.27
     1FD.23 --> 1FD.22
+    1FD.23 --> 1FD.40
     1FD.24 --> 1FD.25
     1FD.25 --> 1FD.27
     1FD.26 --> 1FD.28
@@ -731,6 +734,7 @@ graph TD
     1FD.31 --> 1FD.22
     1FD.32 --> 1FD.20
     1FD.33 --> m1B
+    1FD.40 --> m1B
     1FD.34 --> 1FD.35
     1FD.35 --> m1
     1FD.36 --> 1FD.37 & 1FD.39

--- a/docs/roadmaps/mvp.md
+++ b/docs/roadmaps/mvp.md
@@ -6,7 +6,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 |          | Status                  | Next Up           | Blocked           |
 | -------- | ----------------------- | ----------------- | ----------------- |
-| **FD**   | In progress             | 1FD.24, 1FD.29, 1FD.36, 1FD.40 | — |
+| **FD**   | In progress             | 1FD.25, 1FD.30, 1FD.36, 1FD.40 | — |
 | **GN**   | Not started             | 2GN.1, 2GN.2, 2GN.17, 2GN.22 | —      |
 | **WS**   | Not started             | —                 | 2GN.56            |
 | **UI**   | Not started             | —                 | 3WS.15            |
@@ -53,10 +53,10 @@ description: MVP implementation roadmap from foundation through NPC social syste
 - [x] 1FD.21. `src/lib/types/documents.ts` — `DocumentNode`, `DocumentLineage`, `DerivationType`, `DerivationEvent`, `DocumentScope`, `Audience`, `PublicationRegister`, `DocumentPerception` (simplified MVP shape per doc 10 §11: `audienceReach`, `takeawayDivergence`, `citationCount`; `DocumentNode` unavoidably references `DisseminationState`, so 1FD.22's full member list landed alongside it too)
 - [x] 1FD.22. `src/lib/types/documents.ts` — `DisseminationState`, `DisseminationEvent`, `DisseminationDetails`, `PeerReviewState`, `Retraction`, `TaintedLineage` (`DisseminationState` scoped to MVP's four states per doc 10 §11 — `presented`/`collected` deferred; completed alongside 1FD.21 since `DocumentNode` depends on it directly)
 - [x] 1FD.23. `src/lib/types/venues.ts` — `VenueDefinition`, `ContainerModel`, `TemporalMode`, `SubmissionWindow`, `EditorialProcess`, `AudienceEncounter`, `VenueScope`, `VenueClassification` (doc 07 §3.1 transcribed verbatim, term-denominated; doc 10 §6.4's week-denominated `VenueTemporalProfile` overlaps it — reconciliation owned by 1FD.40)
-- [ ] 1FD.24. `src/lib/types/contradiction.ts` — `Contradiction` union, `MaterialContradiction`, `TemporalContradiction`, `CulturalContradiction`, `StructuralContradiction`, `ProvenanceContradiction`, `CorpusContradiction`, `RarityContradiction`, `MaterialProvenanceContradiction` (all eight members per doc 06 §4.2; `CulturalContradiction.agentClaim` references a claimId at MVP — doc 06's profileId applies once cultural-profile documents land post-MVP)
-- [ ] 1FD.25. `src/lib/types/contradiction.ts` — `ContradictionSeverity`, `ContradictionQueue`, `QueuedContradiction`, `DiegeticSurface`, `Resolution`, `HypothesisStrain` (resolves the two cross-file `TODO(1FD.25)` stand-ins in `interpretation.ts`)
+- [x] 1FD.24. `src/lib/types/contradiction.ts` — `Contradiction` union, `MaterialContradiction`, `TemporalContradiction`, `CulturalContradiction`, `StructuralContradiction`, `ProvenanceContradiction`, `CorpusContradiction`, `RarityContradiction`, `MaterialProvenanceContradiction` (all eight members per doc 06 §4.2; `CulturalContradiction.agentClaim` references a claimId at MVP — doc 06's profileId applies once cultural-profile documents land post-MVP; `ContradictionSeverity` landed here from 1FD.25's bullet since all eight members reference it directly, per the 1FD.21/22 precedent)
+- [ ] 1FD.25. `src/lib/types/contradiction.ts` — `ContradictionQueue`, `QueuedContradiction`, `DiegeticSurface`, `Resolution`, `HypothesisStrain` (resolves the two cross-file `TODO(1FD.25)` stand-ins in `interpretation.ts`; `ContradictionSeverity` already landed with 1FD.24)
 - [ ] 1FD.27. `src/lib/types/career.ts` — `RoleRequirement`, `DisseminationCareerEffect`, `PeerReviewCareerEvent`, `ReviewerFeedback`
-- [ ] 1FD.29. `src/lib/types/scholars.ts` — `MinimalScholar`, `NPCScholarSeed`, `SimulatedExcavation`
+- [x] 1FD.29. `src/lib/types/scholars.ts` — `MinimalScholar`, `NPCScholarSeed`, `SimulatedExcavation` (doc 07 §5.1 + doc 05 §4.1; `MinimalScholar.specialism.methodologicalBias` narrowed from the doc's `string` to interpretation.ts's `MethodologicalBias` union per the 1FD.31 register-narrowing precedent)
 - [ ] 1FD.30. `src/lib/types/corpus.ts` — `ProfessionalCorpus`, `FrequencyRecord`, `ContextFrequency`, `ConsensusStatement`, `Debate`, `DebatePosition`, `CoverageBudget`
 - [ ] 1FD.33. `src/lib/types/save.ts` — `SaveFile`, `SerialisedWorldState`, `SerialisedInterpretiveModel`, `SerialisedTermState`, `CURRENT_SAVE_VERSION`
 - [ ] 1FD.40. `src/lib/types/venues.ts` — `VenueTemporalProfile` (doc 10 §6.4, week-denominated: `submissionMode`, `openWeeks`, `cycleLengthWeeks`, `reviewLeadTimeWeeks`, `publicationLeadTimeWeeks`); reconcile with doc 07 §3.1's term-denominated `TemporalMode`/`SubmissionWindow` (supersede or coexist — doc 12's week-conversion sweep suggests weeks are canonical, cf. §2.9 precedent) and record the resolution in doc 12; consumed downstream by 9CR.5 (venue generation sets temporal properties) and 9CR.22 (venue cycles at term boundaries) — **depends on 1FD.23**
@@ -688,13 +688,13 @@ graph TD
     1FD.21["`*1FD.21*<br/>types/documents core`"]:::done
     1FD.22["`*1FD.22*<br/>types/documents dissem`"]:::done
     1FD.23["`*1FD.23*<br/>types/venues.ts`"]:::done
-    1FD.24["`*1FD.24*<br/>types/contradiction core`"]:::open
-    1FD.25["`*1FD.25*<br/>types/contradiction queue`"]:::blocked
+    1FD.24["`*1FD.24*<br/>types/contradiction core`"]:::done
+    1FD.25["`*1FD.25*<br/>types/contradiction queue`"]:::open
     1FD.26["`*1FD.26*<br/>types/career core`"]:::done
     1FD.27["`*1FD.27*<br/>types/career drains`"]:::blocked
     1FD.28["`*1FD.28*<br/>types/term.ts`"]:::done
-    1FD.29["`*1FD.29*<br/>types/scholars.ts`"]:::open
-    1FD.30["`*1FD.30*<br/>types/corpus.ts`"]:::blocked
+    1FD.29["`*1FD.29*<br/>types/scholars.ts`"]:::done
+    1FD.30["`*1FD.30*<br/>types/corpus.ts`"]:::open
     1FD.31["`*1FD.31*<br/>types/description.ts`"]:::done
     1FD.32["`*1FD.32*<br/>types/visibility.ts`"]:::done
     1FD.33["`*1FD.33*<br/>types/save.ts`"]:::blocked

--- a/src/lib/types/contradiction.ts
+++ b/src/lib/types/contradiction.ts
@@ -1,0 +1,169 @@
+/**
+ * Contradiction type definitions (doc 06 §4.2).
+ *
+ * A contradiction is a detectable divergence between an agent's interpretive model and the world
+ * state's occluded properties (doc 06 §4.1). Not all errors are contradictions — only those that
+ * produce observable consequences: contradictions are revealed by consequences, not by checking
+ * answers. Detection compares claims in an `InterpretiveModel` against occluded properties in
+ * world state (doc 11 §2.5, §2.7); observable and inferable properties can't produce
+ * contradictions, and engine-internal properties are never compared. Detection is agent-generic —
+ * the same logic runs against player and NPC models alike.
+ *
+ * `ContradictionSeverity` belongs to 1FD.25's bullet but landed here early because all eight
+ * union members reference it directly (the 1FD.21/22 precedent). The queue, resolution and strain
+ * shapes remain with 1FD.25. This module is data shapes only, no behaviour.
+ */
+
+/**
+ * How serious a contradiction is (doc 06 §4.2). Drives queue ordering, strain accumulation and
+ * the prominence of diegetic surfacing (1FD.25 shapes).
+ */
+export type ContradictionSeverity = 'minor' | 'moderate' | 'major' | 'critical';
+
+/**
+ * An agent claims a culture doesn't use a material, but a new artefact attributed to that culture
+ * contains it (doc 06 §4.2). Targets material presence/absence — contrast
+ * `MaterialProvenanceContradiction`, which targets the explanation for a material's presence.
+ */
+export interface MaterialContradiction {
+	type: 'material';
+	description: string;
+
+	agentClaim: { claimId: string; claim: string };
+	contradictingEvidence: { artefactId: string; property: string };
+	severity: ContradictionSeverity;
+}
+
+/**
+ * An agent's chronology places a culture before a period, but a new artefact has provenance that
+ * contradicts this (doc 06 §4.2).
+ */
+export interface TemporalContradiction {
+	type: 'temporal';
+	description: string;
+
+	agentClaim: { claimId: string; claim: string };
+	contradictingEvidence: { artefactId: string; provenance: string };
+	severity: ContradictionSeverity;
+}
+
+/**
+ * An agent's cultural profile predicts something that a new artefact contradicts (doc 06 §4.2).
+ *
+ * MVP deviation: `agentClaim` references a `claimId` rather than doc 06's `profileId` — cultural
+ * profiles as documents land post-MVP, so at MVP the contradicted position is a claim in the
+ * agent's interpretive model (roadmap 1FD.24 note).
+ */
+export interface CulturalContradiction {
+	type: 'cultural';
+	description: string;
+
+	agentClaim: { claimId: string; claim: string };
+	contradictingEvidence: { artefactId: string; property: string };
+	severity: ContradictionSeverity;
+}
+
+/**
+ * An agent's inference chain contains a logical impossibility (doc 06 §4.2). Unlike the
+ * evidence-driven members, this is internal to the model — no new artefact is required to
+ * surface it.
+ */
+export interface StructuralContradiction {
+	type: 'structural';
+	description: string;
+
+	affectedProof: { proofId: string; brokenStep: number };
+	reason: string;
+	severity: ContradictionSeverity;
+}
+
+/**
+ * An agent attributes an artefact to a context that conflicts with its actual origin
+ * (doc 06 §4.2). Targets artefact-level context — contrast `MaterialProvenanceContradiction`,
+ * which targets material-level geological origin.
+ */
+export interface ProvenanceContradiction {
+	type: 'provenance';
+	description: string;
+
+	agentClaim: { studyId: string; claim: string };
+	contradictingEvidence: { artefactId: string; actualProvenance: string };
+	severity: ContradictionSeverity;
+}
+
+/**
+ * An agent's claim conflicts with established professional consensus (doc 06 §4.2). The corpus
+ * may itself be wrong — this is a disagreement, not proof of error. Corpus contradictions are
+ * unique in that resolution may involve the agent *challenging* the consensus rather than
+ * deferring to it, feeding the claim magnitude system (doc 05 §4.6).
+ */
+export interface CorpusContradiction {
+	type: 'corpus';
+	description: string;
+
+	agentClaim: { claimId: string; claim: string };
+	corpusPosition: { publicationIds: string[]; consensus: string };
+	severity: ContradictionSeverity;
+}
+
+/**
+ * An agent's perception of rarity diverges from occluded reality (doc 06 §4.2). Can occur at any
+ * of the four rarity levels (doc 05 §10): geological (material commoner/rarer than the agent
+ * thinks), cultural (production frequency doesn't match the agent's model), site
+ * (survival/recovery bias has skewed the sample) or perceived (the profession's consensus on
+ * rarity is itself wrong). Detection compares the agent's sample against the occluded
+ * distribution, accounting for which sites have been excavated and how thoroughly.
+ */
+export interface RarityContradiction {
+	type: 'rarity';
+	description: string;
+
+	agentPerception: { claim: string; inferenceId?: string };
+	occludedDistribution: {
+		level: 'geological' | 'cultural' | 'site' | 'perceived';
+
+		/** Description of actual rarity. */
+		actualFrequency: string;
+	};
+
+	/** What's skewing the agent's perception. */
+	sampleBias?: string;
+
+	severity: ContradictionSeverity;
+}
+
+/**
+ * An agent's claim about *why* a material is present is wrong, even though the material
+ * identification itself may be correct (doc 06 §4.2) — e.g. "obsidian is a trade import" when
+ * there's a local deposit, or "local clay" when geological provenance shows distant origin.
+ * Distinct from `MaterialContradiction` (presence/absence) and `ProvenanceContradiction`
+ * (artefact-level context).
+ */
+export interface MaterialProvenanceContradiction {
+	type: 'material-provenance';
+	description: string;
+
+	agentClaim: { inferenceId: string; claim: string };
+	contradictingEvidence: {
+		artefactId: string;
+		materialId: string;
+
+		/** From `MaterialProvenance` (doc 05 §7.1). */
+		geologicalOrigin: string;
+	};
+	severity: ContradictionSeverity;
+}
+
+/**
+ * Every way an agent's interpretive model can detectably diverge from occluded world state
+ * (doc 06 §4.2), discriminated on `type`.
+ */
+export type Contradiction =
+	| MaterialContradiction
+	| TemporalContradiction
+	| CulturalContradiction
+	| StructuralContradiction
+	| ProvenanceContradiction
+	| CorpusContradiction
+	| RarityContradiction
+	| MaterialProvenanceContradiction;

--- a/src/lib/types/scholars.ts
+++ b/src/lib/types/scholars.ts
@@ -1,0 +1,94 @@
+/**
+ * NPC scholar type definitions (doc 07 §5.1, doc 05 §4.1).
+ *
+ * At MVP, NPCs are reactive functions, not simulated agents (doc 07 §5): they have no research
+ * agendas, publication schedules or political manoeuvres — they exist as surfaces off which the
+ * player's actions bounce. They originate from the professional corpus generated during world
+ * creation (doc 05, stage 4.5), each arriving with a name, specialism, methodological bias and a
+ * body of published work carrying calibrated wrongness.
+ *
+ * NPC interpretive models are agent-generic — the same `InterpretiveModel` interface the player
+ * uses (doc 11 §2.6), generated statically during corpus creation rather than evolving
+ * dynamically. NPC errors are simply claims in their models that diverge from occluded ground
+ * truth: subjective positions, not metadata flags (the previous `corpusErrors` field is retired,
+ * doc 07 §5.1). Engine functions (lens calculation, contradiction detection, peer review) accept
+ * any `InterpretiveModel` without knowing whose it is. This module is data shapes only, no
+ * behaviour.
+ */
+
+import type { InterpretiveModel, MethodologicalBias } from './interpretation.ts';
+import type { FunctionTag } from './tags.ts';
+import type { SiteType } from './world.ts';
+
+/**
+ * An NPC scholar as the interactive layer sees them (doc 07 §5.1), sitting on top of the corpus
+ * data generated at world creation.
+ *
+ * `specialism.methodologicalBias` is narrowed from doc 07's `string` (whose comment names the
+ * three doc 07 §5.1 values) to the existing `MethodologicalBias` union per the register-narrowing
+ * precedent (1FD.31), which also admits the authored `'generalist'` neutral member.
+ */
+export interface MinimalScholar {
+	id: string;
+	name: string;
+
+	specialism: {
+		/** Which cultures they care about. */
+		cultureAffinity: string[];
+
+		methodologicalBias: MethodologicalBias;
+	};
+
+	/** Agent-generic — same interface as the player's model (doc 11 §2.6). */
+	interpretiveModel: InterpretiveModel;
+
+	/** Document node IDs (doc 10) from world generation. */
+	corpusPublications: string[];
+
+	relationship: {
+		/** 0–1: how seriously they take the player. */
+		respect: number;
+
+		/** 0–1: how much they agree with the player's published work. */
+		agreement: number;
+	};
+}
+
+/**
+ * An NPC scholar as world generation seeds them (doc 05 §4.1), before the interactive layer
+ * exists. Some are active (the player will interact with them later); some are retired or
+ * deceased — foundational figures whose work shaped the field but who aren't active participants.
+ */
+export interface NPCScholarSeed {
+	id: string;
+	name: string;
+	specialisation: FunctionTag[];
+	cultureFocus: string[];
+
+	/** Agent-generic: same interface as the player (doc 11 §2.6). */
+	interpretiveModel: InterpretiveModel;
+
+	sitePreference: SiteType[];
+	careerStage: 'emeritus' | 'senior' | 'mid' | 'early';
+	status: 'active' | 'retired' | 'deceased';
+	publicationCount: number;
+}
+
+/**
+ * One NPC excavation campaign simulated at world generation (doc 05 §4.1). Each NPC "excavated"
+ * certain sites, biased by their interests and institutional access — a military historian digs
+ * fortifications, not temples. The simulation is a low-fidelity sampling and synthesis pass over
+ * world state, not a high-fidelity replay: sample artefacts biased by NPC site selection, filter
+ * through NPC interpretive lenses, produce summary claims.
+ */
+export interface SimulatedExcavation {
+	npcId: string;
+	siteId: string;
+	siteType: SiteType;
+	cultureId: string;
+	phaseId: string;
+	artefactsSampled: number;
+	materialDistribution: Map<string, number>;
+	formDistribution: Map<string, number>;
+	contextDistribution: Map<string, number>;
+}

--- a/src/lib/types/venues.ts
+++ b/src/lib/types/venues.ts
@@ -15,8 +15,11 @@
  * defines a separate week-denominated `VenueTemporalProfile` covering overlapping ground
  * (submission windows, lead times). Doc 12 records doc 10's week conversion but no reconciliation
  * with doc 07; roadmap task 1FD.40 owns `VenueTemporalProfile` and the reconciliation. Doc 07's
- * shapes are transcribed as written. This module is data shapes only, no behaviour.
+ * shapes are transcribed as written, save the `methodologicalLeaning` narrowing noted on the
+ * field. This module is data shapes only, no behaviour.
  */
+
+import type { MethodologicalBias } from './interpretation.ts';
 
 /**
  * How publication is structured at a venue (doc 07 §3.1).
@@ -42,7 +45,13 @@ export interface SubmissionWindow {
 	/** How windows align with the academic calendar, if they do. */
 	alignment?: 'term-start' | 'term-end' | 'annual' | 'event-tied';
 
-	/** Whether a window is currently open. */
+	/**
+	 * Whether a window is currently open. Runtime-derived state sitting inside an otherwise static
+	 * definition (transcribed verbatim from doc 07 §3.1); doc 10 §6.4's schedule-based
+	 * `VenueTemporalProfile` derives openness from the current week instead, and 1FD.40's
+	 * reconciliation owns this field's fate. Consumers should derive window status from the
+	 * current term rather than trusting a stored flag.
+	 */
 	open: boolean;
 }
 
@@ -140,8 +149,12 @@ export interface VenueDefinition {
 		/** Which periods. */
 		periodAffinities?: string[];
 
-		/** Structuralist, materialist, etc. */
-		methodologicalLeaning?: string;
+		/**
+		 * Structuralist, materialist, etc. Narrowed from doc 07's `string` to the existing
+		 * `MethodologicalBias` union per the 1FD.31 register-narrowing precedent, matching
+		 * `MinimalScholar.specialism.methodologicalBias`.
+		 */
+		methodologicalLeaning?: MethodologicalBias;
 	};
 }
 

--- a/src/lib/types/venues.ts
+++ b/src/lib/types/venues.ts
@@ -14,8 +14,8 @@
  * Known spec tension: `TemporalMode` here is term-denominated per doc 07 §3.1, while doc 10 §6.4
  * defines a separate week-denominated `VenueTemporalProfile` covering overlapping ground
  * (submission windows, lead times). Doc 12 records doc 10's week conversion but no reconciliation
- * with doc 07; no roadmap task owns `VenueTemporalProfile`. Doc 07's shapes are transcribed as
- * written. This module is data shapes only, no behaviour.
+ * with doc 07; roadmap task 1FD.40 owns `VenueTemporalProfile` and the reconciliation. Doc 07's
+ * shapes are transcribed as written. This module is data shapes only, no behaviour.
  */
 
 /**

--- a/src/lib/types/venues.ts
+++ b/src/lib/types/venues.ts
@@ -1,0 +1,169 @@
+/**
+ * Venue type definitions (doc 07 §3.1, doc 10 §4.4).
+ *
+ * Venues are where documents meet the world: generated during world creation alongside the
+ * professional corpus, each with properties that determine what work they accept, how they
+ * evaluate it and what career weight publication there carries. A venue is not a category — it is
+ * a bundle of properties from which descriptive labels can be derived, consistent with artefact
+ * classification (doc 05) and document form classification (doc 10). A venue might *read* as "a
+ * prestigious specialist journal" or "a regional museum exhibition programme", but those labels
+ * emerge; they are never assigned. Prestige is likewise computed from properties, never stored as
+ * a tier. Venues are static once generated for MVP — shifting attributes (reputation damage,
+ * editorial turnover, scope drift) are deferred post-MVP (doc 11).
+ *
+ * Known spec tension: `TemporalMode` here is term-denominated per doc 07 §3.1, while doc 10 §6.4
+ * defines a separate week-denominated `VenueTemporalProfile` covering overlapping ground
+ * (submission windows, lead times). Doc 12 records doc 10's week conversion but no reconciliation
+ * with doc 07; no roadmap task owns `VenueTemporalProfile`. Doc 07's shapes are transcribed as
+ * written. This module is data shapes only, no behaviour.
+ */
+
+/**
+ * How publication is structured at a venue (doc 07 §3.1).
+ */
+export type ContainerModel =
+	/** One-of-many in a curated issue. */
+	| 'periodical'
+	/** Self-contained work (book, monograph). */
+	| 'standalone'
+	/** Exhibition, gallery, spatial installation. */
+	| 'curated-space'
+	/** Conference, lecture series. */
+	| 'event';
+
+/**
+ * When a venue accepts submissions (doc 07 §3.1). Seasonal windows create calendar pressure: the
+ * player must decide whether to rush a document to meet a window or wait for the next cycle.
+ */
+export interface SubmissionWindow {
+	/** Windows per year (1 = annual, 3 = termly, etc.). */
+	frequency: number;
+
+	/** How windows align with the academic calendar, if they do. */
+	alignment?: 'term-start' | 'term-end' | 'annual' | 'event-tied';
+
+	/** Whether a window is currently open. */
+	open: boolean;
+}
+
+/**
+ * When and how often a venue accepts and publishes work (doc 07 §3.1).
+ */
+export interface TemporalMode {
+	submissionWindow: SubmissionWindow;
+
+	/** Terms between acceptance and publication (1–3 typical). */
+	leadTime: number;
+
+	/** Terms the work remains "current" before fading into the backlist. */
+	visibilityWindow: number | 'indefinite';
+}
+
+/**
+ * How a venue evaluates submitted work (doc 07 §3.1). Determines whether dissemination triggers
+ * named peer review (doc 07 §3.3) and feeds the venue's computed prestige.
+ */
+export type EditorialProcess =
+	/** Named reviewers evaluate the submission. */
+	| 'peer-review'
+	/** Editor invites or commissions work. */
+	| 'editorial-commission'
+	/** Curator selects work for exhibition/collection. */
+	| 'curatorial-selection'
+	/** Minimal gatekeeping. */
+	| 'open-submission';
+
+/**
+ * How the audience encounters work published at a venue (doc 07 §3.1).
+ */
+export type AudienceEncounter =
+	/** Readers go looking for it (journals, books). */
+	| 'sought'
+	/** Encountered in situ (museum, public space). */
+	| 'situated'
+	/** Audience is present and committed (lecture, conference). */
+	| 'captive';
+
+/**
+ * A venue's subject range (doc 07 §3.1) — emergent, not categorical. All dimensions are 0–1.
+ */
+export interface VenueScope {
+	/** How many cultures the venue covers. */
+	cultureRange: number;
+
+	/** How many periods. */
+	periodRange: number;
+
+	/** How ecumenical the editorial stance. */
+	methodologicalRange: number;
+}
+
+/**
+ * A venue where documents are disseminated (doc 07 §3.1). Prestige is computed from the prestige
+ * inputs, never assigned: high rigour + narrow scope + long establishment computes differently
+ * from low rigour + broad scope + massive reach, and the career system treats them differently
+ * (specialist credibility versus influence and public profile). Subject focus creates venue–player
+ * fit — mismatched submissions aren't automatically rejected, but face higher scrutiny and a less
+ * sympathetic reviewer pool.
+ */
+export interface VenueDefinition {
+	id: string;
+	name: string;
+
+	// Structural properties — how publication works here
+	containerModel: ContainerModel;
+	temporalMode: TemporalMode;
+
+	/** Whether the audience encounters actual artefacts alongside the work. */
+	artefactSituated: boolean;
+
+	editorialProcess: EditorialProcess;
+	audienceEncounter: AudienceEncounter;
+
+	// Prestige inputs — computed, not assigned
+	/** 0–1: how demanding the review process is. */
+	editorialRigour: number;
+
+	scope: VenueScope;
+
+	/** 0–1: size of audience. */
+	reach: number;
+
+	/** 0–1: longevity and institutional entrenchment. */
+	establishment: number;
+
+	/** What this venue cares about. */
+	subjectFocus: {
+		/** Which cultures this venue gravitates toward. */
+		cultureAffinities?: string[];
+
+		/** Which periods. */
+		periodAffinities?: string[];
+
+		/** Structuralist, materialist, etc. */
+		methodologicalLeaning?: string;
+	};
+}
+
+/**
+ * A venue's reclassification of a submitted document (doc 10 §4.4). The venue applies its own
+ * classification standards, so its form label may differ from the system's. Reclassification is a
+ * diegetic event ("the editors suggest it be published as a research note rather than a full
+ * article") which the player can accept, withdraw from or appeal, with career consequences for
+ * each.
+ */
+export interface VenueClassification {
+	venueId: string;
+
+	/** What the system called the document. */
+	submittedFormLabel: string;
+
+	/** What the venue calls it. */
+	venueFormLabel: string;
+
+	/** True if the two labels differ. */
+	reclassified: boolean;
+
+	/** Why the venue reclassified, e.g. "Insufficient evidence for full article". */
+	reclassificationReason?: string;
+}


### PR DESCRIPTION
# Add Venue, Contradiction and Scholar Types
## Overview
Completes three more type-definition tasks from Milestone 1 Foundation: 1FD.23 (venues), 1FD.24 (contradictions) and 1FD.29 (scholars). These are pure data shapes with no behaviour, transcribed from design docs 05, 06 and 07 with doc-referenced commentary throughout.

Along the way this surfaced a spec tension between doc 07's term-denominated venue timing and doc 10's week-denominated `VenueTemporalProfile`; rather than resolving it ad hoc, a new roadmap task (1FD.40) now owns that reconciliation.

Closes: none.
## Summary
Imagine a town planner who, before anyone has laid a single brick, files detailed blueprints for the publishing house, the courthouse where scholars get caught contradicting themselves and the retirement home for professors who were wrong about everything decades ago. Nobody lives in these buildings yet. The buildings don't exist. But the filing cabinet now knows exactly what shape every future argument will be.
> [!TIP]
> Nothing to do after pulling — type-only additions, no config, dependency or migration steps.
---
## Changes
<details>
<summary><strong><code>src/lib/types/venues.ts</code></strong> — new (1FD.23)</summary>

- `VenueDefinition` with structural properties (`ContainerModel`, `TemporalMode`, `EditorialProcess`, `AudienceEncounter`) and prestige inputs (rigour, `VenueScope`, reach, establishment)
- Prestige is computed from properties, never stored as a tier, per doc 07 §3.1
- `VenueClassification` for venue-side reclassification of submitted documents (doc 10 §4.4)
- Header documents the known doc 07/doc 10 temporal-denomination tension and points at 1FD.40

</details>

<details>
<summary><strong><code>src/lib/types/contradiction.ts</code></strong> — new (1FD.24)</summary>

- All eight `Contradiction` union members per doc 06 §4.2: material, temporal, cultural, structural, provenance, corpus, rarity and material-provenance
- `ContradictionSeverity` pulled forward from 1FD.25's bullet since every member references it (same precedent as 1FD.21/22)
- MVP deviation recorded: `CulturalContradiction.agentClaim` uses a claimId rather than doc 06's profileId until cultural-profile documents land post-MVP
- Queue, resolution and strain shapes deliberately left for 1FD.25

</details>

<details>
<summary><strong><code>src/lib/types/scholars.ts</code></strong> — new (1FD.29)</summary>

- `MinimalScholar` (doc 07 §5.1): the interactive-layer view with specialism, relationship and an agent-generic `InterpretiveModel`
- `NPCScholarSeed` (doc 05 §4.1): the world-generation view, including retired and deceased foundational figures
- `SimulatedExcavation`: low-fidelity NPC dig campaigns sampled at world creation
- `methodologicalBias` narrowed from the doc's `string` to the existing `MethodologicalBias` union per the 1FD.31 register-narrowing precedent

</details>

<details>
<summary><strong><code>docs/roadmaps/mvp.md</code></strong> — roadmap bookkeeping</summary>

- 1FD.23, 1FD.24 and 1FD.29 marked complete with implementation notes
- New task 1FD.40 added, owning `VenueTemporalProfile` and the doc 07/doc 10 temporal reconciliation (depends on 1FD.23)
- Status table, dependency graph and Next Up entries updated (now 1FD.25, 1FD.30, 1FD.36, 1FD.40)

</details>

---

Verification: `deno task check` (293 files, 0 errors), `deno lint` and `deno fmt --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added foundational support for classifying and describing contradictions by type and severity.
  * Added data models for scholars, simulated excavations, academic venues, submission processes, audiences, and venue-based classification.
* **Documentation**
  * Updated the MVP roadmap and progress map with completed foundational milestones, revised next steps, and new prerequisite relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->