### PR TITLE
Contradiction Queue and Career Effect Types

### DIFF
--- a/docs/roadmaps/mvp.md
+++ b/docs/roadmaps/mvp.md
@@ -6,7 +6,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 |          | Status                  | Next Up           | Blocked           |
 | -------- | ----------------------- | ----------------- | ----------------- |
-| **FD**   | In progress             | 1FD.25, 1FD.30, 1FD.36, 1FD.40 | — |
+| **FD**   | In progress             | 1FD.30, 1FD.36, 1FD.40 | — |
 | **GN**   | Not started             | 2GN.1, 2GN.2, 2GN.17, 2GN.22 | —      |
 | **WS**   | Not started             | —                 | 2GN.56            |
 | **UI**   | Not started             | —                 | 3WS.15            |
@@ -54,8 +54,8 @@ description: MVP implementation roadmap from foundation through NPC social syste
 - [x] 1FD.22. `src/lib/types/documents.ts` — `DisseminationState`, `DisseminationEvent`, `DisseminationDetails`, `PeerReviewState`, `Retraction`, `TaintedLineage` (`DisseminationState` scoped to MVP's four states per doc 10 §11 — `presented`/`collected` deferred; completed alongside 1FD.21 since `DocumentNode` depends on it directly)
 - [x] 1FD.23. `src/lib/types/venues.ts` — `VenueDefinition`, `ContainerModel`, `TemporalMode`, `SubmissionWindow`, `EditorialProcess`, `AudienceEncounter`, `VenueScope`, `VenueClassification` (doc 07 §3.1 transcribed verbatim, term-denominated; doc 10 §6.4's week-denominated `VenueTemporalProfile` overlaps it — reconciliation owned by 1FD.40)
 - [x] 1FD.24. `src/lib/types/contradiction.ts` — `Contradiction` union, `MaterialContradiction`, `TemporalContradiction`, `CulturalContradiction`, `StructuralContradiction`, `ProvenanceContradiction`, `CorpusContradiction`, `RarityContradiction`, `MaterialProvenanceContradiction` (all eight members per doc 06 §4.2; `CulturalContradiction.agentClaim` references a claimId at MVP — doc 06's profileId applies once cultural-profile documents land post-MVP; `ContradictionSeverity` landed here from 1FD.25's bullet since all eight members reference it directly, per the 1FD.21/22 precedent)
-- [ ] 1FD.25. `src/lib/types/contradiction.ts` — `ContradictionQueue`, `QueuedContradiction`, `DiegeticSurface`, `Resolution`, `HypothesisStrain` (resolves the two cross-file `TODO(1FD.25)` stand-ins in `interpretation.ts`; `ContradictionSeverity` already landed with 1FD.24)
-- [ ] 1FD.27. `src/lib/types/career.ts` — `RoleRequirement`, `DisseminationCareerEffect`, `PeerReviewCareerEvent`, `ReviewerFeedback`
+- [x] 1FD.25. `src/lib/types/contradiction.ts` — `ContradictionQueue`, `QueuedContradiction`, `DiegeticSurface`, `Resolution`, `HypothesisStrain` (doc 06 §4.4–§4.6, §5 verbatim; `HypothesisStrain` is the canonical strain type per doc 12 §2.15; all six `DiegeticSurface` channels typed though MVP drives only `impossible-artefact`/`field-report` — doc 07 §5.2's NPC generators already return the other shapes; `ContradictionQueue` shaped per doc 06, with doc 08 §3.4's bare-`Contradiction`-push store sketch JSDoc-flagged as illustrative pseudo-code to reconcile at the store task; `Resolution.contradictionId` flagged as a doc 06 forward reference — `Contradiction` members carry no `id` at MVP, the identity scheme belongs to the detection engine (7CD.x); resolves the two cross-file `TODO(1FD.25)` stand-ins in `interpretation.ts`; `ContradictionSeverity` already landed with 1FD.24)
+- [x] 1FD.27. `src/lib/types/career.ts` — `RoleRequirement`, `DisseminationCareerEffect`, `PeerReviewCareerEvent`, `ReviewerFeedback` (doc 07 §3.2–§3.3, §4.2 verbatim; `DisseminationTransition` hoisted from §3.2 per the `ContradictionSeverity` precedent and scoped to MVP's three live transitions — `published-to-collected` dropped per the 1FD.22 `DisseminationState` precedent; authored `ReputationEffect` hoist for the `{dimension, delta, basis}` shape doc 07 inlines identically on both career-event types; doc 08 §5's singular `reputationEffect` read in the `resolvePeerReview` sketch JSDoc-flagged — doc 07's plural array governs; `ActivityOutcome`'s provisional note updated now this task has landed, it stays provisional until activity execution gets an owning task per doc 13 §5; file remains import-free, cross-domain references by plain `string` id)
 - [x] 1FD.29. `src/lib/types/scholars.ts` — `MinimalScholar`, `NPCScholarSeed`, `SimulatedExcavation` (doc 07 §5.1 + doc 05 §4.1; `MinimalScholar.specialism.methodologicalBias` narrowed from the doc's `string` to interpretation.ts's `MethodologicalBias` union per the 1FD.31 register-narrowing precedent)
 - [ ] 1FD.30. `src/lib/types/corpus.ts` — `ProfessionalCorpus`, `FrequencyRecord`, `ContextFrequency`, `ConsensusStatement`, `Debate`, `DebatePosition`, `CoverageBudget`
 - [ ] 1FD.33. `src/lib/types/save.ts` — `SaveFile`, `SerialisedWorldState`, `SerialisedInterpretiveModel`, `SerialisedTermState`, `CURRENT_SAVE_VERSION`
@@ -689,9 +689,9 @@ graph TD
     1FD.22["`*1FD.22*<br/>types/documents dissem`"]:::done
     1FD.23["`*1FD.23*<br/>types/venues.ts`"]:::done
     1FD.24["`*1FD.24*<br/>types/contradiction core`"]:::done
-    1FD.25["`*1FD.25*<br/>types/contradiction queue`"]:::open
+    1FD.25["`*1FD.25*<br/>types/contradiction queue`"]:::done
     1FD.26["`*1FD.26*<br/>types/career core`"]:::done
-    1FD.27["`*1FD.27*<br/>types/career drains`"]:::blocked
+    1FD.27["`*1FD.27*<br/>types/career effects`"]:::done
     1FD.28["`*1FD.28*<br/>types/term.ts`"]:::done
     1FD.29["`*1FD.29*<br/>types/scholars.ts`"]:::done
     1FD.30["`*1FD.30*<br/>types/corpus.ts`"]:::open

--- a/src/lib/types/career.ts
+++ b/src/lib/types/career.ts
@@ -1,14 +1,21 @@
 /**
- * Career and reputation type definitions (doc 07 §2, §2.2, §4.0–§4.1).
+ * Career and reputation type definitions (doc 07 §2, §2.2, §3.2–§3.3, §4.0–§4.2).
  *
  * Reputation is multidimensional, not a single score: a player can be respected for rigour while
  * dismissed for originality. Reputation gates certain activities and its dimensions shift from
  * career events (doc 07 §2.1) — publishing, retracting, resolving or ignoring contradictions, and
  * so on. `CareerState` and `CareerActivity` describe the concurrent-undertakings model (doc 07
  * §4.1): a term's activities compete for a shared time and energy budget rather than a single
- * "pick one action" slot. Time and energy accounting itself (terms, weeks, background drains) is
- * owned by `src/lib/types/term.ts` (roadmap 1FD.28); this file references those concepts only via
- * plain numbers, taking no dependency on it. This module is data shapes only, no behaviour.
+ * "pick one action" slot. The career-event shapes (roadmap 1FD.27) tie the document tradition
+ * back to reputation: dissemination transitions and named peer review each carry itemised,
+ * diegetically-explained reputation effects (doc 07 §3.2–§3.3), and `RoleRequirement` gates rank
+ * advancement (doc 07 §4.2).
+ *
+ * Time and energy accounting itself (terms, weeks, background drains) is owned by
+ * `src/lib/types/term.ts` (roadmap 1FD.28); this file references those concepts only via plain
+ * numbers, taking no dependency on it. Likewise documents, venues and scholars are referenced by
+ * plain `string` ids, keeping this file import-free. This module is data shapes only, no
+ * behaviour.
  */
 
 /**
@@ -188,9 +195,10 @@ export type ActivityType =
  * Provisional: doc 07 §4.1 references `ActivityOutcome` only as `CareerActivity.outcomes` with the
  * inline comment "Possible results" and never defines its shape, nor is it owned by any roadmap
  * task. This is an invented minimal shape, not doc-specified: a human-readable description plus an
- * optional reputation delta and an optional follow-on unlock. Expect this to firm up once roadmap
- * 1FD.27 (which owns the closely related `PeerReviewCareerEvent`, `ReviewerFeedback` and
- * `DisseminationCareerEffect`) lands.
+ * optional reputation delta and an optional follow-on unlock. Roadmap 1FD.27 has since landed the
+ * doc-specified career-event shapes below, whose itemised `ReputationEffect[]` (delta + diegetic
+ * basis per effect) is the sibling idiom; this shape stays provisional until activity execution
+ * gets an owning task (post-MVP, doc 13 §5), at which point it may adopt that idiom.
  */
 export interface ActivityOutcome {
 	/** Human-readable description of this outcome, shown to the player. */
@@ -201,4 +209,146 @@ export interface ActivityOutcome {
 
 	/** Id of an activity this outcome unlocks, if any. */
 	unlocksActivity?: string;
+}
+
+/**
+ * One itemised reputation consequence of a career event (doc 07 §3.2–§3.3, where this shape is
+ * inlined identically on both `DisseminationCareerEffect` and `PeerReviewCareerEvent`; hoisted
+ * here per the `ContradictionSeverity`/`DatingConfidence` precedent). `basis` keeps career
+ * mechanics inside the fiction: every reputation change has a diegetic explanation the player can
+ * read — never "+0.1 rigour", always "The editorial board of the Lowland Studies Quarterly noted
+ * the thoroughness of your stratigraphic analysis" (doc 07 §3.2).
+ */
+export interface ReputationEffect {
+	/** Which dimension of `Reputation['dimensions']` this effect adjusts. */
+	dimension: keyof Reputation['dimensions'];
+
+	/** Signed adjustment, computed from venue properties + document properties. */
+	delta: number;
+
+	/** Diegetic explanation of why this effect occurred. */
+	basis: string;
+}
+
+/**
+ * A document's move along the dissemination pipeline, as a career event (doc 07 §3.2). Each
+ * transition escalates the stakes: circulation is a faint work-in-progress signal, submission a
+ * declaration of readiness judged by the venue's editorial board, publication the major career
+ * event where peer review occurs and lens strength locks.
+ *
+ * MVP scope: three live transitions. Doc 07 §3.2's fourth member, `published-to-collected`, is
+ * dropped per the `DisseminationState` precedent (documents.ts, roadmap 1FD.22) — the `collected`
+ * state is itself deferred for MVP, and doc 07 §3.2 defers the transition explicitly.
+ */
+export type DisseminationTransition =
+	| 'private-to-circulated'
+	| 'circulated-to-submitted'
+	| 'submitted-to-published';
+
+/**
+ * The career consequences of one dissemination state transition (doc 07 §3.2). Reputation effects
+ * are not flat bonuses — they scale with venue properties, so publication in a high-rigour,
+ * well-established venue carries more reputational weight (and lens strength) than a low-rigour,
+ * broad-reach outlet, while the latter generates more influence.
+ */
+export interface DisseminationCareerEffect {
+	transition: DisseminationTransition;
+
+	/** The venue involved in the transition (`VenueDefinition` id, venues.ts). */
+	venueId: string;
+
+	/** Itemised, diegetically-explained reputation consequences. */
+	reputationEffects: ReputationEffect[];
+
+	/** Contribution to commitment lens strength (doc 04's graduated calculation). */
+	lensEffect: number;
+}
+
+/**
+ * A named reviewer's assessment of a submitted document (doc 07 §3.3). Peer review is named, not
+ * anonymous (doc 11 §2.1): the reviewer is identified, their published positions are known, and
+ * their assessment is a public professional act. The commitment fields connect review to the
+ * knowledge model (doc 06) — a reviewer engages with specific claims, so disputed commitments are
+ * potential contradiction seeds, and endorsed commitments from a hostile reviewer are particularly
+ * strong validation.
+ */
+export interface ReviewerFeedback {
+	scholarName: string;
+
+	/** Diegetic text — the reviewer's letter. */
+	assessment: string;
+
+	/** Specific issues raised. */
+	methodologicalConcerns: string[];
+
+	/** Which of the document's commitments the reviewer challenges. */
+	commitmentsDisputed: string[];
+
+	/** Which the reviewer finds well-supported. */
+	commitmentsEndorsed: string[];
+}
+
+/**
+ * The career consequences of one peer review (doc 07 §3.3) — a social event, not a binary verdict.
+ * `revisions-requested` never mutates the submission (documents are immutable once disseminated,
+ * doc 10 §1): the player derives a new document node and resubmits, while the original persists
+ * with the impression it made. Review is bidirectional — the relationship effect records what the
+ * exchange did to standing between the two scholars.
+ *
+ * Doc 08 §5's `resolvePeerReview` sketch reads a singular `reputationEffect` field; doc 07 §3.3's
+ * plural array governs the shape (roadmap 1FD.27 note) and the sketch reconciles when the store
+ * method lands.
+ */
+export interface PeerReviewCareerEvent {
+	/** The submitted document (`DocumentNode` id, documents.ts). */
+	documentNodeId: string;
+
+	/** The venue reviewed for (`VenueDefinition` id, venues.ts). */
+	venueId: string;
+
+	/** NPC scholar id of the named reviewer (`MinimalScholar` id, scholars.ts). */
+	reviewerId: string;
+
+	outcome: 'accepted' | 'revisions-requested' | 'rejected';
+	feedback: ReviewerFeedback;
+
+	/** Itemised, diegetically-explained reputation consequences. */
+	reputationEffects: ReputationEffect[];
+
+	/**
+	 * What the review did to the player–reviewer relationship; deltas apply to
+	 * `MinimalScholar.relationship`'s `respect`/`agreement` (scholars.ts).
+	 */
+	relationshipEffect: {
+		scholarId: string;
+		respectDelta: number;
+		agreementDelta: number;
+	};
+}
+
+/**
+ * What a scholar must have accumulated before advancing to a given `AcademicRole` (doc 07 §4.2).
+ * Advancement is checked at term boundaries and delivered diegetically — a letter of appointment,
+ * a new nameplate — never an explicit "level up". The per-role requirement table is data evaluated
+ * by the career engine (roadmap 9CR.16), not typed here.
+ *
+ * MVP note: progression gates on reputation, publications and terms-in-role only — `activities`
+ * stays in the interface with `[]` for the MVP transition so activity gating can return per role
+ * without an interface change (doc 12 §2.12, doc 13 §5).
+ */
+export interface RoleRequirement {
+	/** Minimum values per reputation dimension; absent dimensions are ungated. */
+	reputation: Partial<Record<keyof Reputation['dimensions'], number>>;
+
+	/** Documents at 'published' dissemination state or beyond. */
+	publishedDocuments: number;
+
+	/** At least N documents published at venues above this prestige threshold. */
+	minVenuePrestige?: number;
+
+	/** Career activities that must have been completed (doc 07 §4.1). */
+	activities: ActivityType[];
+
+	/** Minimum terms spent in current role before eligible. */
+	minTermsInRole?: number;
 }

--- a/src/lib/types/contradiction.ts
+++ b/src/lib/types/contradiction.ts
@@ -1,5 +1,5 @@
 /**
- * Contradiction type definitions (doc 06 §4.2).
+ * Contradiction type definitions (doc 06 §4.2, §4.4–§4.6, §5).
  *
  * A contradiction is a detectable divergence between an agent's interpretive model and the world
  * state's occluded properties (doc 06 §4.1). Not all errors are contradictions — only those that
@@ -9,9 +9,11 @@
  * contradictions, and engine-internal properties are never compared. Detection is agent-generic —
  * the same logic runs against player and NPC models alike.
  *
- * `ContradictionSeverity` belongs to 1FD.25's bullet but landed here early because all eight
- * union members reference it directly (the 1FD.21/22 precedent). The queue, resolution and strain
- * shapes remain with 1FD.25. This module is data shapes only, no behaviour.
+ * Beyond the `Contradiction` union itself (roadmap 1FD.24), this file owns the accumulation,
+ * surfacing, resolution and strain shapes (doc 06 §4.4–§4.6, §5; roadmap 1FD.25): detected
+ * contradictions queue rather than interrupt, reach the agent through in-world channels, and are
+ * addressed through a retcon flow whose evasive resolutions accumulate strain. This module is data
+ * shapes only, no behaviour.
  */
 
 /**
@@ -167,3 +169,118 @@ export type Contradiction =
 	| CorpusContradiction
 	| RarityContradiction
 	| MaterialProvenanceContradiction;
+
+/**
+ * The in-world channel through which a contradiction reaches an agent (doc 06 §4.5), discriminated
+ * on `channel`. Contradictions never appear as system alerts — they arrive as impossible finds,
+ * pointed letters, awkward student questions. Surfacing is decoupled from detection: the system
+ * selects the most appropriate channel for the contradiction type from whatever channels are
+ * implemented.
+ *
+ * MVP note: only `impossible-artefact` and `field-report` are driven at MVP (doc 06 §4.5) —
+ * `peer-letter` and `student-question` need skeletal NPCs, `review-rejection` needs the
+ * publication system, `public-criticism` needs the popular writing track. All six are typed now
+ * because doc 07 §5.2's NPC challenge generators already return the `peer-letter` and
+ * `student-question` shapes.
+ */
+export type DiegeticSurface =
+	| { channel: 'impossible-artefact'; artefactId: string; anomaly: string }
+	| { channel: 'peer-letter'; scholarName: string; argument: string }
+	| { channel: 'student-question'; studentName: string; question: string }
+	| { channel: 'review-rejection'; journalName: string; reason: string }
+	| { channel: 'field-report'; siteName: string; finding: string }
+	| { channel: 'public-criticism'; sourceName: string; claim: string };
+
+/**
+ * The record of an agent addressing a contradiction via the retcon flow (doc 06 §4.6):
+ * acknowledge, trace the affected inference chain, decide, cascade to dependent documents, record.
+ * `revise` changes the hypothesis and recalibrates the lens; `reinterpret` keeps the hypothesis
+ * but explains the evidence away, accumulating `HypothesisStrain`; `reject` disputes the evidence
+ * itself, costing credibility and raising the reputational pressure of future contradictions.
+ *
+ * `contradictionId` is a doc 06 forward reference: `Contradiction` members carry no `id` field at
+ * MVP, so the identity scheme it points at is owned by the detection engine (7CD.x tasks), not
+ * typed here.
+ */
+export interface Resolution {
+	type: 'revise' | 'reinterpret' | 'reject';
+	contradictionId: string;
+
+	/** Ids of all documents that changed in the cascade. */
+	affectedDocuments: string[];
+
+	/** The player's in-fiction justification for the decision. */
+	playerExplanation: string;
+
+	/** Term index when the resolution was recorded. */
+	resolvedAtTerm: number;
+}
+
+/**
+ * One detected contradiction awaiting (or having received) the agent's attention (doc 06 §4.4).
+ * Queued, not forced: the agent decides when to engage, while `termsUnresolved` drives escalating
+ * diegetic pressure the longer it sits.
+ */
+export interface QueuedContradiction {
+	contradiction: Contradiction;
+
+	/** Term index when detected. */
+	detectedAtTerm: number;
+
+	/** How many terms since detection (drives escalation). */
+	termsUnresolved: number;
+
+	/** How it reached the player; absent while detected but not yet surfaced (doc 06 §4.5). */
+	surfacedVia?: DiegeticSurface;
+
+	/** Player has seen it. */
+	acknowledged: boolean;
+
+	resolved: boolean;
+	resolution?: Resolution;
+}
+
+/**
+ * An agent's accumulated unresolved contradictions (doc 06 §4.4). Visible only as a diegetic
+ * element — mounting unease, peer whispers, unanswered letters — never as a system alert.
+ *
+ * Shape per doc 06 §4.4: the store sketch in doc 08 §3.4 pushes a bare `Contradiction` into
+ * `items` and sums the string-valued `severity` — illustrative pseudo-code that the eventual store
+ * action (3WS.x) reconciles against this shape; doc 06 governs (roadmap 1FD.25 note).
+ */
+export interface ContradictionQueue {
+	items: QueuedContradiction[];
+
+	/** Sum of all unresolved severities, as scored by the engine. */
+	totalSeverity: number;
+
+	/** Increases each term with unresolved contradictions. */
+	reputationalPressure: number;
+}
+
+/**
+ * Mounting tension between what an agent believes and what the evidence supports (doc 06 §5) —
+ * the slow-burn alternative to a clean contradiction, and the canonical strain type (doc 12
+ * §2.15; the older name `StrainScore` is retired). Reinterpretations, partial mismatches and
+ * out-of-context motif appearances each add a little; past a threshold the hypothesis becomes
+ * "stressed" and diegetic surfacing grows more frequent and pointed. The threshold itself is
+ * engine behaviour, not typed here.
+ */
+export interface HypothesisStrain {
+	hypothesisId: string;
+
+	/** 0–1, accumulates over time. */
+	strainScore: number;
+
+	/** What is contributing strain, itemised so the pressure is legible in retrospect. */
+	factors: Array<{
+		type:
+			| 'reinterpretation'
+			| 'partial-mismatch'
+			| 'missing-evidence'
+			| 'peer-doubt'
+			| 'decorative-mismatch';
+		description: string;
+		contribution: number;
+	}>;
+}

--- a/src/lib/types/interpretation.ts
+++ b/src/lib/types/interpretation.ts
@@ -13,6 +13,7 @@
  * and the player store's `id`-keyed, `status`-filtered `Map` usage (doc 08 §3.4).
  */
 
+import type { ContradictionQueue, HypothesisStrain } from './contradiction.ts';
 import type { DescriptionRegister } from './lens.ts';
 import type { ContextTag, FunctionTag, MaterialTag } from './tags.ts';
 
@@ -420,26 +421,6 @@ export interface MethodologicalProfile {
 		culturalEvidence: number;
 	};
 }
-
-/**
- * TODO(1FD.25): opaque placeholder for `HypothesisStrain`, owned by
- * `src/lib/types/contradiction.ts` (doc 06 §5) — the canonical strain type; the older name
- * `StrainScore` is retired in favour of it (roadmap 1FD.19 note). Nothing in this file
- * dereferences its fields, so an opaque `unknown` typechecks everywhere it is used
- * (`InterpretiveModel.strainScores`) while avoiding a duplicate definition that would conflict
- * when 1FD.25 lands. Swap for `import type { HypothesisStrain } from './contradiction.ts'` and
- * delete this line then.
- */
-type HypothesisStrain = unknown;
-
-/**
- * TODO(1FD.25): opaque placeholder for `ContradictionQueue`, owned by
- * `src/lib/types/contradiction.ts` (doc 06 §5). Nothing in this file dereferences its fields, so
- * an opaque `unknown` typechecks everywhere it is used (`InterpretiveModel.contradictionQueue`)
- * while avoiding a duplicate definition that would conflict when 1FD.25 lands. Swap for
- * `import type { ContradictionQueue } from './contradiction.ts'` and delete this line then.
- */
-type ContradictionQueue = unknown;
 
 /**
  * The agent-generic shape of an epistemic agent's subjective state (doc 08 §3.2) — claims about


### PR DESCRIPTION
## Overview

Lands roadmap tasks 1FD.25 and 1FD.27, the next two Milestone 1 type-system tasks.

- **1FD.25** adds `ContradictionQueue`, `QueuedContradiction`, `DiegeticSurface`, `Resolution` and `HypothesisStrain` to `contradiction.ts` (doc 06 §4.4–§4.6, §5), and swaps `interpretation.ts`'s two `TODO(1FD.25)` opaque placeholders for real imports.
- **1FD.27** adds `RoleRequirement`, `DisseminationCareerEffect`, `PeerReviewCareerEvent` and `ReviewerFeedback` to `career.ts` (doc 07 §3.2–§3.3, §4.2), plus two hoists: `DisseminationTransition` (scoped to MVP's three live transitions) and an authored `ReputationEffect` for the shape doc 07 inlines twice.

## Summary

The museum's complaints department finally has a filing cabinet. Previously, when a visitor pointed out that the "Bronze Age ceremonial dagger" was clearly a 1970s letter opener, the curator would nod politely and the observation would evaporate. Now every awkward question gets a numbered ticket, sits in a tray marked MOUNTING UNEASE, gains a little more menace each term it goes unanswered, and eventually arrives at the curator's desk disguised as a student's innocent question or a devastating letter from Dr Okafor. Meanwhile HR has installed a promotions ladder with the rungs labelled: climb it by publishing, lose your footing by explaining away one too many letter openers.

> [!TIP]
> No action needed after pulling. Types only, no runtime surface, no new dependencies.

---

## Changes

<details>
<summary><code>src/lib/types/contradiction.ts</code> — queue, surfacing, resolution and strain shapes (1FD.25)</summary>

- All five shapes transcribed verbatim from doc 06 §4.4–§4.6 and §5; `HypothesisStrain` is the canonical strain type per doc 12 §2.15 (`StrainScore` retired)
- All six `DiegeticSurface` channels typed although MVP drives only `impossible-artefact` and `field-report` (doc 07 §5.2's NPC generators already return the other shapes)
- `Resolution.contradictionId` JSDoc-flagged as a doc 06 forward reference; `Contradiction` members carry no `id` at MVP
- Doc 08 §3.4's bare-push store sketch flagged as illustrative pseudo-code; doc 06 governs the shape
</details>

<details>
<summary><code>src/lib/types/interpretation.ts</code> — placeholder swap (1FD.25)</summary>

- Deletes the two `TODO(1FD.25)` opaque `unknown` stand-ins and imports `ContradictionQueue` and `HypothesisStrain` from `contradiction.ts`, exactly as the stand-ins' own notes instructed
- No cycle introduced; `contradiction.ts` imports nothing
</details>

<details>
<summary><code>src/lib/types/career.ts</code> — career event shapes (1FD.27)</summary>

- Four interfaces transcribed verbatim from doc 07 §3.2–§3.3 and §4.2
- `DisseminationTransition` hoisted and scoped to three MVP transitions; `published-to-collected` dropped per the 1FD.22 `DisseminationState` precedent
- Authored `ReputationEffect` hoist for the `{dimension, delta, basis}` shape doc 07 inlines identically twice
- Doc 08 §5's singular `reputationEffect` read flagged; doc 07's plural array governs
- `ActivityOutcome`'s provisional note updated now its anticipated firming-up point (this task) has passed
- File remains import-free; documents, venues and scholars referenced by plain `string` ids
</details>

<details>
<summary><code>docs/roadmaps/mvp.md</code> — bookkeeping</summary>

- 1FD.25 and 1FD.27 flipped to `[x]` with implementation-note parentheticals
- FD Next Up cell now `1FD.30, 1FD.36, 1FD.40` (1FD.33 stays blocked on 1FD.30)
- Mermaid nodes flipped to `:::done`; 1FD.27's stale `types/career drains` label corrected to `types/career effects`
</details>

---

**Verification:** `deno task check` 0 errors, `deno fmt --check` and `deno lint` clean, `deno test` 29 passed. No `TODO(1FD.25)` remains anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured data definitions for career events, reputation changes, dissemination outcomes, peer review, and role requirements.
  * Added structured contradiction tracking for surfaced contradictions, resolutions, queues, escalation, and hypothesis strain.
  * Improved interpretation data to use the standardized contradiction and strain structures.

* **Documentation**
  * Updated the MVP roadmap to mark items `1FD.25` and `1FD.27` as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->