### PR TITLE
Project Explorer Shell, Seed Input and PRNG Panel

### DIFF
--- a/docs/roadmaps/mvp.md
+++ b/docs/roadmaps/mvp.md
@@ -6,7 +6,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 |          | Status                  | Next Up           | Blocked           |
 | -------- | ----------------------- | ----------------- | ----------------- |
-| **FD**   | In progress             | 1FD.30, 1FD.36, 1FD.40 | — |
+| **FD**   | In progress             | 1FD.30, 1FD.37, 1FD.40 | — |
 | **GN**   | Not started             | 2GN.1, 2GN.2, 2GN.17, 2GN.22 | —      |
 | **WS**   | Not started             | —                 | 2GN.56            |
 | **UI**   | Not started             | —                 | 3WS.15            |
@@ -63,7 +63,6 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 **Project Explorer shell**
 
-- [ ] 1FD.36. Create route `/dev/explorer` with layout and nav
 - [ ] 1FD.37. Seed input field component
 - [ ] 1FD.38. PRNG output display — generate N values, visual determinism check
 - [ ] 1FD.39. Type index panel — list all registered interfaces with field summaries
@@ -109,6 +108,10 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 - [x] 1FD.34. Configure `deno test`, verify runner executes against engine skeleton (`deno task test` wired in `deno.json`; `@std/assert@^1.0.19` added; `tsconfig.json` excludes `*.test.ts` from `svelte-check` since Deno test files use `Deno.ns`/`jsr:` specifiers svelte-check can't resolve)
 - [x] 1FD.35. Create test fixture helpers — mock culture, mock world seed, mock artefact factories (split per-domain, mirroring `src/lib/types/`: `tests/fixtures/world.ts` keeps `mockWorldSeed`, now returning the real `WorldSeed` instead of a local stand-in; `tests/fixtures/culture.ts` adds `mockCulture`; `tests/fixtures/artefact.ts` adds `mockNormalisedArtefact` and `mockArtefact`; each takes a shallow-merge `overrides` param that replaces whole top-level branches rather than deep-merging, since several fields are `Map`s or multi-level nested objects; `tsconfig.json`'s `exclude` extended to `tests/**/*.test.ts` alongside the existing `src/**/*.test.ts` for the same Deno-only reason)
+
+**Project Explorer shell**
+
+- [x] 1FD.36. Create route `/dev/explorer` with layout and nav (sub-route model: each future panel is a child route under `src/routes/dev/explorer/` plus one entry in the route-private `panels.ts` registry — `{id, label, path, milestone, status}` — which drives both the sidebar `menu` nav and the overview landing table; planned M1 panels render as `menu-disabled` placeholders until 1FD.38/39 flip their status; seed input, 1FD.37, is a shell control not a panel — the layout's header bar reserves its right-hand mount point; `src/routes/dev/+layout.ts` guards the whole `/dev` subtree with a 404 outside `dev` builds; also created the root `src/routes/+layout.svelte` as a prerequisite fix — nothing imported `app.css`, so Tailwind/DaisyUI styles never loaded anywhere)
 </details>
 
 <details>
@@ -700,8 +703,8 @@ graph TD
     1FD.33["`*1FD.33*<br/>types/save.ts`"]:::blocked
     1FD.34["`*1FD.34*<br/>Configure deno test`"]:::done
     1FD.35["`*1FD.35*<br/>Test fixture helpers (partial)`"]:::open
-    1FD.36["`*1FD.36*<br/>Explorer route + layout`"]:::open
-    1FD.37["`*1FD.37*<br/>Explorer seed input`"]:::blocked
+    1FD.36["`*1FD.36*<br/>Explorer route + layout`"]:::done
+    1FD.37["`*1FD.37*<br/>Explorer seed input`"]:::open
     1FD.38["`*1FD.38*<br/>Explorer PRNG display`"]:::blocked
     1FD.39["`*1FD.39*<br/>Explorer type index`"]:::blocked
     1FD.40["`*1FD.40*<br/>types/venues temporal`"]:::open

--- a/docs/roadmaps/mvp.md
+++ b/docs/roadmaps/mvp.md
@@ -6,7 +6,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 |          | Status                  | Next Up           | Blocked           |
 | -------- | ----------------------- | ----------------- | ----------------- |
-| **FD**   | In progress             | 1FD.30, 1FD.37, 1FD.40 | — |
+| **FD**   | In progress             | 1FD.30, 1FD.40 | — |
 | **GN**   | Not started             | 2GN.1, 2GN.2, 2GN.17, 2GN.22 | —      |
 | **WS**   | Not started             | —                 | 2GN.56            |
 | **UI**   | Not started             | —                 | 3WS.15            |
@@ -63,8 +63,6 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 **Project Explorer shell**
 
-- [ ] 1FD.37. Seed input field component
-- [ ] 1FD.38. PRNG output display — generate N values, visual determinism check
 - [ ] 1FD.39. Type index panel — list all registered interfaces with field summaries
 
 <a name="m1-blocked"><h4>Blocked (Milestone 1)</h4></a>
@@ -112,6 +110,8 @@ description: MVP implementation roadmap from foundation through NPC social syste
 **Project Explorer shell**
 
 - [x] 1FD.36. Create route `/dev/explorer` with layout and nav (sub-route model: each future panel is a child route under `src/routes/dev/explorer/` plus one entry in the route-private `panels.ts` registry — `{id, label, path, milestone, status}` — which drives both the sidebar `menu` nav and the overview landing table; planned M1 panels render as `menu-disabled` placeholders until 1FD.38/39 flip their status; seed input, 1FD.37, is a shell control not a panel — the layout's header bar reserves its right-hand mount point; `src/routes/dev/+layout.ts` guards the whole `/dev` subtree with a 404 outside `dev` builds; also created the root `src/routes/+layout.svelte` as a prerequisite fix — nothing imported `app.css`, so Tailwind/DaisyUI styles never loaded anywhere)
+- [x] 1FD.37. Seed input field component (route-private `SeedInput.svelte` mounted in the layout header's reserved slot; the seed lives in the `?seed=` URL query param so it survives reload and repro cases are shareable via link — `seed.ts` owns `DEFAULT_SEED` and `getSeed(url)`, with absent/empty falling back to the default and committing the default or an empty value removing the param; the layout nav and overview table links now carry `page.url.search` so the seed survives panel switches)
+- [x] 1FD.38. PRNG output display (child route `prng/+page.svelte` per the 1FD.36 sub-route model, `panels.ts` entry flipped to `available`; draws N values — default 20, clamped 1–1000 — from two *independent* `createPrng(seed)` instances and compares index-by-index with exact float equality; the visual determinism check is a badge verdict plus per-row ✓/✗ over full-precision values; everything is `$derived` from the URL seed and N, so changing the header seed regenerates the panel live with no generate button)
 </details>
 
 <details>
@@ -704,8 +704,8 @@ graph TD
     1FD.34["`*1FD.34*<br/>Configure deno test`"]:::done
     1FD.35["`*1FD.35*<br/>Test fixture helpers (partial)`"]:::open
     1FD.36["`*1FD.36*<br/>Explorer route + layout`"]:::done
-    1FD.37["`*1FD.37*<br/>Explorer seed input`"]:::open
-    1FD.38["`*1FD.38*<br/>Explorer PRNG display`"]:::blocked
+    1FD.37["`*1FD.37*<br/>Explorer seed input`"]:::done
+    1FD.38["`*1FD.38*<br/>Explorer PRNG display`"]:::done
     1FD.39["`*1FD.39*<br/>Explorer type index`"]:::blocked
     1FD.40["`*1FD.40*<br/>types/venues temporal`"]:::open
     1FD.6 --> 1FD.7 & 1FD.8 & 1FD.9

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import '../app.css';
+
+	let { children } = $props();
+</script>
+
+{@render children()}

--- a/src/routes/dev/+layout.ts
+++ b/src/routes/dev/+layout.ts
@@ -1,7 +1,8 @@
 import { dev } from '$app/environment';
 import { error } from '@sveltejs/kit';
+import type { LayoutLoad } from './$types';
 
 /** Dev-only subtree: every route under /dev is hidden in production builds. */
-export function load(): void {
+export const load: LayoutLoad = () => {
 	if (!dev) error(404, 'Not found');
-}
+};

--- a/src/routes/dev/+layout.ts
+++ b/src/routes/dev/+layout.ts
@@ -1,0 +1,7 @@
+import { dev } from '$app/environment';
+import { error } from '@sveltejs/kit';
+
+/** Dev-only subtree: every route under /dev is hidden in production builds. */
+export function load(): void {
+	if (!dev) error(404, 'Not found');
+}

--- a/src/routes/dev/explorer/+layout.svelte
+++ b/src/routes/dev/explorer/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { page } from '$app/state';
 import { panels } from './panels';
+import SeedInput from './SeedInput.svelte';
 
 let { children } = $props();
 
@@ -13,8 +14,9 @@ const milestones = [...new Set(panels.map((panel) => panel.milestone))].sort((a,
 			<span class="text-lg font-bold">Project Explorer</span>
 			<span class="badge badge-neutral badge-sm">dev workbench</span>
 		</div>
-		<!-- Right-hand region reserved for shell controls (seed input, 1FD.37) -->
-		<div class="flex-none"></div>
+		<div class="flex-none">
+			<SeedInput />
+		</div>
 	</header>
 
 	<div class="flex flex-1">
@@ -25,7 +27,11 @@ const milestones = [...new Set(panels.map((panel) => panel.milestone))].sort((a,
 					{#each panels.filter((panel) => panel.milestone === milestone) as panel (panel.id)}
 						{#if panel.status === 'available'}
 							<li>
-								<a href={panel.path} class={page.url.pathname === panel.path ? 'menu-active' : ''}>
+								<!-- Links carry the query string so the seed (1FD.37) survives panel switches -->
+								<a
+									href={panel.path + page.url.search}
+									class={page.url.pathname === panel.path ? 'menu-active' : ''}
+								>
 									{panel.label}
 								</a>
 							</li>

--- a/src/routes/dev/explorer/+layout.svelte
+++ b/src/routes/dev/explorer/+layout.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+import { page } from '$app/state';
+import { panels } from './panels';
+
+let { children } = $props();
+
+const milestones = [...new Set(panels.map((panel) => panel.milestone))].sort((a, b) => a - b);
+</script>
+
+<div class="flex min-h-screen flex-col">
+	<header class="navbar bg-base-200 border-base-300 border-b">
+		<div class="flex-1 gap-3">
+			<span class="text-lg font-bold">Project Explorer</span>
+			<span class="badge badge-neutral badge-sm">dev workbench</span>
+		</div>
+		<!-- Right-hand region reserved for shell controls (seed input, 1FD.37) -->
+		<div class="flex-none"></div>
+	</header>
+
+	<div class="flex flex-1">
+		<aside class="bg-base-200 w-56 shrink-0">
+			<ul class="menu w-full">
+				{#each milestones as milestone (milestone)}
+					<li class="menu-title">M{milestone}</li>
+					{#each panels.filter((panel) => panel.milestone === milestone) as panel (panel.id)}
+						{#if panel.status === 'available'}
+							<li>
+								<a href={panel.path} class={page.url.pathname === panel.path ? 'menu-active' : ''}>
+									{panel.label}
+								</a>
+							</li>
+						{:else}
+							<li class="menu-disabled">
+								<span>{panel.label}</span>
+							</li>
+						{/if}
+					{/each}
+				{/each}
+			</ul>
+		</aside>
+
+		<main class="flex-1 p-6">
+			{@render children()}
+		</main>
+	</div>
+</div>

--- a/src/routes/dev/explorer/+page.svelte
+++ b/src/routes/dev/explorer/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { page } from '$app/state';
 import { panels } from './panels';
 </script>
 
@@ -24,7 +25,8 @@ import { panels } from './panels';
 				<tr>
 					<td>
 						{#if panel.status === 'available'}
-							<a href={panel.path} class="link">{panel.label}</a>
+							<!-- Links carry the query string so the seed (1FD.37) survives panel switches -->
+							<a href={panel.path + page.url.search} class="link">{panel.label}</a>
 						{:else}
 							{panel.label}
 						{/if}

--- a/src/routes/dev/explorer/+page.svelte
+++ b/src/routes/dev/explorer/+page.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+import { panels } from './panels';
+</script>
+
+<h2 class="text-2xl font-bold">Overview</h2>
+
+<p class="mt-4 max-w-prose">
+	The Project Explorer is the developer workbench for Those Who Came Before. It is not the player
+	UI: each milestone adds panels here so every system can be generated, inspected and verified
+	before anything downstream consumes it.
+</p>
+
+<div class="mt-6 overflow-x-auto">
+	<table class="table max-w-xl">
+		<thead>
+			<tr>
+				<th>Panel</th>
+				<th>Milestone</th>
+				<th>Status</th>
+			</tr>
+		</thead>
+		<tbody>
+			{#each panels as panel (panel.id)}
+				<tr>
+					<td>
+						{#if panel.status === 'available'}
+							<a href={panel.path} class="link">{panel.label}</a>
+						{:else}
+							{panel.label}
+						{/if}
+					</td>
+					<td>M{panel.milestone}</td>
+					<td>
+						{#if panel.status === 'available'}
+							<span class="badge badge-success badge-sm">available</span>
+						{:else}
+							<span class="badge badge-ghost badge-sm">planned</span>
+						{/if}
+					</td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+</div>

--- a/src/routes/dev/explorer/SeedInput.svelte
+++ b/src/routes/dev/explorer/SeedInput.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+import { goto } from '$app/navigation';
+import { page } from '$app/state';
+import { DEFAULT_SEED, getSeed } from './seed';
+
+const urlSeed = $derived(getSeed(page.url));
+
+// Local draft so typing doesn't fight the URL round-trip; resynced whenever the URL seed
+// changes from elsewhere (back/forward navigation, pasted link).
+let draft = $state(getSeed(page.url));
+
+$effect(() => {
+	draft = urlSeed;
+});
+
+function commitSeed(): void {
+	const seed = draft.trim();
+	const url = new URL(page.url);
+
+	if (seed === '' || seed === DEFAULT_SEED) {
+		url.searchParams.delete('seed');
+	} else {
+		url.searchParams.set('seed', seed);
+	}
+
+	goto(url, { replaceState: true, keepFocus: true, noScroll: true });
+}
+</script>
+
+<label class="input input-sm input-bordered flex items-center gap-2">
+	<span class="label-text font-semibold">Seed</span>
+	<input
+		type="text"
+		class="grow font-mono"
+		placeholder={DEFAULT_SEED}
+		bind:value={draft}
+		onchange={commitSeed}
+		onkeydown={(event) => {
+			if (event.key === 'Enter') commitSeed();
+		}}
+	/>
+</label>

--- a/src/routes/dev/explorer/panels.ts
+++ b/src/routes/dev/explorer/panels.ts
@@ -1,0 +1,25 @@
+/**
+ * Panel registry for the Project Explorer (doc 09).
+ *
+ * Each milestone adds panels by appending an entry here and creating the matching
+ * child route directory; the shell's nav and overview table render from this list.
+ */
+export interface ExplorerPanel {
+	id: string;
+	label: string;
+	path: string;
+	milestone: number;
+	status: 'available' | 'planned';
+}
+
+export const panels: ExplorerPanel[] = [
+	{ id: 'overview', label: 'Overview', path: '/dev/explorer', milestone: 1, status: 'available' },
+	{ id: 'prng', label: 'PRNG Output', path: '/dev/explorer/prng', milestone: 1, status: 'planned' },
+	{
+		id: 'types',
+		label: 'Type Index',
+		path: '/dev/explorer/types',
+		milestone: 1,
+		status: 'planned',
+	},
+];

--- a/src/routes/dev/explorer/panels.ts
+++ b/src/routes/dev/explorer/panels.ts
@@ -14,7 +14,13 @@ export interface ExplorerPanel {
 
 export const panels: ExplorerPanel[] = [
 	{ id: 'overview', label: 'Overview', path: '/dev/explorer', milestone: 1, status: 'available' },
-	{ id: 'prng', label: 'PRNG Output', path: '/dev/explorer/prng', milestone: 1, status: 'planned' },
+	{
+		id: 'prng',
+		label: 'PRNG Output',
+		path: '/dev/explorer/prng',
+		milestone: 1,
+		status: 'available',
+	},
 	{
 		id: 'types',
 		label: 'Type Index',

--- a/src/routes/dev/explorer/prng/+page.svelte
+++ b/src/routes/dev/explorer/prng/+page.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+import { page } from '$app/state';
+import { createPrng } from '$lib/engine/prng';
+import { getSeed } from '../seed';
+
+const seed = $derived(getSeed(page.url));
+
+let count = $state(20);
+const clampedCount = $derived(Math.min(1000, Math.max(1, Math.floor(count) || 1)));
+
+// Two independent generators from the same seed: if the engine's determinism guarantee holds,
+// their sequences are identical index-by-index.
+const rows = $derived.by(() => {
+	const runA = createPrng(seed);
+	const runB = createPrng(seed);
+
+	return Array.from({ length: clampedCount }, (_, index) => {
+		const a = runA();
+		const b = runB();
+		return { index, a, b, match: a === b };
+	});
+});
+
+const deterministic = $derived(rows.every((row) => row.match));
+</script>
+
+<h2 class="text-2xl font-bold">PRNG Output</h2>
+
+<p class="mt-4 max-w-prose">
+	Draws {clampedCount} values from two independent generators created with the same seed. Every row
+	must match exactly: any mismatch means the engine's determinism guarantee is broken.
+</p>
+
+<div class="mt-6 flex flex-wrap items-center gap-4">
+	<label class="input input-sm input-bordered flex w-40 items-center gap-2">
+		<span class="label-text font-semibold">N</span>
+		<input type="number" class="grow" min="1" max="1000" bind:value={count} />
+	</label>
+
+	<span class="text-sm">
+		seed: <code class="bg-base-200 rounded px-1 font-mono">{seed}</code>
+	</span>
+
+	{#if deterministic}
+		<span class="badge badge-success">deterministic — two independent generators agree</span>
+	{:else}
+		<span class="badge badge-error">mismatch — determinism guarantee broken</span>
+	{/if}
+</div>
+
+<div class="mt-6 overflow-x-auto">
+	<table class="table-zebra table max-w-2xl">
+		<thead>
+			<tr>
+				<th>#</th>
+				<th>Run A</th>
+				<th>Run B</th>
+				<th>Match</th>
+			</tr>
+		</thead>
+		<tbody>
+			{#each rows as row (row.index)}
+				<tr>
+					<td>{row.index}</td>
+					<td class="font-mono">{row.a}</td>
+					<td class="font-mono">{row.b}</td>
+					<td>
+						{#if row.match}
+							<span class="text-success">✓</span>
+						{:else}
+							<span class="text-error">✗</span>
+						{/if}
+					</td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+</div>

--- a/src/routes/dev/explorer/seed.ts
+++ b/src/routes/dev/explorer/seed.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared seed for the Project Explorer shell (1FD.37).
+ *
+ * The seed lives in the `?seed=` query param so it survives reloads and repro cases are
+ * shareable via link. Panel nav links must carry `page.url.search` to preserve it.
+ */
+export const DEFAULT_SEED = 'those-who-came-before';
+
+/** Reads the Explorer seed from a URL, falling back to the default when absent or empty. */
+export function getSeed(url: URL): string {
+	return url.searchParams.get('seed') || DEFAULT_SEED;
+}


### PR DESCRIPTION
## Overview

Delivers the Milestone 1 Project Explorer tasks (1FD.36, 1FD.37, 1FD.38). `/dev/explorer` is now a working developer workbench: a nav shell that grows a panel per milestone, a seed input in the header and a PRNG panel that draws the same sequence from two independent generators to prove determinism on screen. The seed rides the URL as `?seed=`, so a reproduction case is a link you can send someone. The whole `/dev` subtree 404s outside dev builds.

Two fixes came along as prerequisites: nothing imported `app.css`, so Tailwind and DaisyUI styles never loaded anywhere in the app; and the `/dev` guard load function now uses the generated `LayoutLoad` type.

## Summary

The archaeology department has dropped a portacabin at the edge of the dig site. Inside there's one machine so far: it rolls two identical dice down parallel chutes and sounds an alarm if they ever disagree, because if the dice can't be trusted, neither can anything built on top of them. By the door is a label maker; stick the same label on two crates and identical futures fall out of both. The label is printed on the door key, so anyone you post the key to walks into the same room.

> [!TIP]
> Nothing to install and no migrations. Run `deno task dev` and visit `/dev/explorer`; the route only exists in dev builds.

---

## Changes

<details>
<summary><strong>Styling fix</strong> — <code>src/routes/+layout.svelte</code></summary>

- New root layout importing `app.css`. Tailwind and DaisyUI (caramellatte/coffee themes) now load globally; previously no file imported the stylesheet, so the app rendered unstyled.

</details>

<details>
<summary><strong>Explorer shell (1FD.36)</strong> — <code>src/routes/dev/</code></summary>

- `dev/+layout.ts`: guards the `/dev` subtree, returning 404 outside dev builds, typed with the generated `LayoutLoad`.
- `dev/explorer/+layout.svelte`: header bar plus sidebar nav grouped by milestone.
- `dev/explorer/panels.ts`: route-private panel registry (`{id, label, path, milestone, status}`) driving both the nav and the overview table. Planned panels render greyed out until their task lands.
- `dev/explorer/+page.svelte`: overview landing page with a panel status table.

</details>

<details>
<summary><strong>Seed input (1FD.37)</strong> — <code>src/routes/dev/explorer/</code></summary>

- `seed.ts`: `DEFAULT_SEED` and `getSeed(url)`; the seed lives in the `?seed=` query param, falling back to the default when absent.
- `SeedInput.svelte`: header control that commits on change or Enter; entering the default or an empty value removes the param.
- Nav and overview links carry the query string, so the seed survives panel switches, reloads and shared links.

</details>

<details>
<summary><strong>PRNG panel (1FD.38)</strong> — <code>src/routes/dev/explorer/prng/</code></summary>

- `prng/+page.svelte`: draws N values (default 20, clamped 1 to 1000) from two independent `createPrng(seed)` instances and compares them index by index with exact float equality. A badge gives the verdict; each row shows both values at full precision with a tick or cross.
- Everything derives from the URL seed and N, so changing the header seed regenerates the panel live.
- `panels.ts` entry flipped to `available`.

</details>

<details>
<summary><strong>Roadmap bookkeeping</strong> — <code>docs/roadmaps/mvp.md</code></summary>

- 1FD.36, 1FD.37 and 1FD.38 marked complete with decision annotations.
- FD status table now points at 1FD.30 and 1FD.40; progress map nodes flipped to done.

</details>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)