### PR TITLE
Corpus Types and One Venue Calendar

### DIFF
--- a/docs/07-career-social-systems.md
+++ b/docs/07-career-social-systems.md
@@ -160,6 +160,11 @@ interface SubmissionWindow {
   alignment?: 'term-start' | 'term-end' | 'annual' | 'event-tied';
   open: boolean;                         // Is a window currently open?
 }
+```
+
+> **Superseded (doc 12, section 2.17):** `TemporalMode` and `SubmissionWindow` above are superseded by doc 10 section 6.4's week-denominated `VenueTemporalProfile` — weeks are the canonical timestamp (doc 12, section 2.9), and `VenueDefinition.temporalMode` is now `temporalProfile: VenueTemporalProfile`. `visibilityWindow` has no week-denominated equivalent and no consumer; it is deferred post-MVP.
+
+```typescript
 
 type EditorialProcess =
   | 'peer-review'                        // Named reviewers evaluate submission

--- a/docs/12-propagation-register.md
+++ b/docs/12-propagation-register.md
@@ -206,6 +206,17 @@ The graduated dissemination lens factor gains a 'presented' value of 0.15, so al
 |---|---|---|
 | 04 | Section 4 `LensStrength` dissemination comment updated with 0.15 (presented) | 2026-07-04 |
 
+### 2.17 Venue Temporal Model: Weeks Canonical (2026-07-11)
+**Origin:** Roadmap task 1FD.40 implementation (2026-07-11)
+**Source of truth:** Doc 10, Section 6.4
+
+Doc 10's week-denominated `VenueTemporalProfile` supersedes doc 07 Section 3.1's term-denominated `TemporalMode`/`SubmissionWindow`. The Section 2.9 week-conversion sweep updated doc 10's profile (openWeeks 0–47, cycle 48) but never doc 07, and `PeerReviewState` (doc 10, Section 6.4) already resolves reviews against absolute weeks. `VenueDefinition.temporalMode` becomes `temporalProfile: VenueTemporalProfile`. `TemporalMode.visibilityWindow` (terms a work remains "current" before fading into the backlist) has no week-denominated equivalent and no consumer in any doc or task; it is deferred post-MVP rather than converted.
+
+| Doc | What changed | Completed |
+|---|---|---|
+| 07 | Section 3.1 supersession note added under `TemporalMode`/`SubmissionWindow`; `visibilityWindow` marked deferred post-MVP | 2026-07-11 |
+| — | `src/lib/types/venues.ts` (1FD.23/1FD.40): `TemporalMode`/`SubmissionWindow` removed, `VenueTemporalProfile` added, `VenueDefinition.temporalProfile` repointed | 2026-07-11 |
+
 ---
 
 *This document is a living register. Items are added during design sessions and resolved during propagation passes.*

--- a/docs/roadmaps/mvp.md
+++ b/docs/roadmaps/mvp.md
@@ -6,7 +6,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 |          | Status                  | Next Up           | Blocked           |
 | -------- | ----------------------- | ----------------- | ----------------- |
-| **FD**   | In progress             | 1FD.33, 1FD.40 | — |
+| **FD**   | In progress             | 1FD.33 | — |
 | **GN**   | Not started             | 2GN.1, 2GN.2, 2GN.17, 2GN.22 | —      |
 | **WS**   | Not started             | —                 | 2GN.56            |
 | **UI**   | Not started             | —                 | 3WS.15            |
@@ -59,7 +59,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 - [x] 1FD.29. `src/lib/types/scholars.ts` — `MinimalScholar`, `NPCScholarSeed`, `SimulatedExcavation` (doc 07 §5.1 + doc 05 §4.1; `MinimalScholar.specialism.methodologicalBias` narrowed from the doc's `string` to interpretation.ts's `MethodologicalBias` union per the 1FD.31 register-narrowing precedent)
 - [x] 1FD.30. `src/lib/types/corpus.ts` — `ProfessionalCorpus`, `FrequencyRecord`, `ContextFrequency`, `ConsensusStatement`, `Debate`, `DebatePosition`, `CoverageBudget` (doc 05 §4.2–§4.3 verbatim; `ContextFrequency` is named by `ProfessionalCorpus.contextAssociations` but shaped nowhere — authored provisional per the `MotifSet`/`ActivityOutcome`/`ProvenancePresentation` precedent, as the reverse index of `FrequencyRecord.byContext` — `{totalObserved, byCulture, associatedMaterials, associatedForms, lastUpdated}` — to firm up at 2GN.53, the first real producer; `SiteType` imported from world.ts per the scholars.ts precedent; cross-domain references — NPC ids, document node ids, culture ids, period ids — stay plain `string` per the career.ts convention)
 - [ ] 1FD.33. `src/lib/types/save.ts` — `SaveFile`, `SerialisedWorldState`, `SerialisedInterpretiveModel`, `SerialisedTermState`, `CURRENT_SAVE_VERSION`
-- [ ] 1FD.40. `src/lib/types/venues.ts` — `VenueTemporalProfile` (doc 10 §6.4, week-denominated: `submissionMode`, `openWeeks`, `cycleLengthWeeks`, `reviewLeadTimeWeeks`, `publicationLeadTimeWeeks`); reconcile with doc 07 §3.1's term-denominated `TemporalMode`/`SubmissionWindow` (supersede or coexist — doc 12's week-conversion sweep suggests weeks are canonical, cf. §2.9 precedent) and record the resolution in doc 12; consumed downstream by 9CR.5 (venue generation sets temporal properties) and 9CR.22 (venue cycles at term boundaries) — **depends on 1FD.23**
+- [x] 1FD.40. `src/lib/types/venues.ts` — `VenueTemporalProfile` (doc 10 §6.4, week-denominated: `submissionMode`, `openWeeks`, `cycleLengthWeeks`, `reviewLeadTimeWeeks`, `publicationLeadTimeWeeks`); reconcile with doc 07 §3.1's term-denominated `TemporalMode`/`SubmissionWindow` (supersede or coexist — doc 12's week-conversion sweep suggests weeks are canonical, cf. §2.9 precedent) and record the resolution in doc 12; consumed downstream by 9CR.5 (venue generation sets temporal properties) and 9CR.22 (venue cycles at term boundaries) — **depends on 1FD.23** (resolved as **supersede**, recorded as doc 12 §2.17: the §2.9 week sweep updated doc 10's profile but never doc 07, and `PeerReviewState` (1FD.22) already works in absolute weeks — so `TemporalMode`/`SubmissionWindow` removed, `VenueDefinition.temporalMode` → `temporalProfile: VenueTemporalProfile`, transcribed verbatim with `venueId` kept as self-referential when embedded; `TemporalMode.visibilityWindow` had no week equivalent and no consumer anywhere — dropped for MVP per the `presented`/`collected` `DisseminationState` precedent rather than converted; doc 07 §3.1 gained a supersession note)
 
 **Project Explorer shell**
 
@@ -707,7 +707,7 @@ graph TD
     1FD.37["`*1FD.37*<br/>Explorer seed input`"]:::done
     1FD.38["`*1FD.38*<br/>Explorer PRNG display`"]:::done
     1FD.39["`*1FD.39*<br/>Explorer type index`"]:::blocked
-    1FD.40["`*1FD.40*<br/>types/venues temporal`"]:::open
+    1FD.40["`*1FD.40*<br/>types/venues temporal`"]:::done
     1FD.6 --> 1FD.7 & 1FD.8 & 1FD.9
     1FD.7 --> m1D
     1FD.8 --> m1D

--- a/docs/roadmaps/mvp.md
+++ b/docs/roadmaps/mvp.md
@@ -6,7 +6,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 |          | Status                  | Next Up           | Blocked           |
 | -------- | ----------------------- | ----------------- | ----------------- |
-| **FD**   | In progress             | 1FD.30, 1FD.40 | — |
+| **FD**   | In progress             | 1FD.33, 1FD.40 | — |
 | **GN**   | Not started             | 2GN.1, 2GN.2, 2GN.17, 2GN.22 | —      |
 | **WS**   | Not started             | —                 | 2GN.56            |
 | **UI**   | Not started             | —                 | 3WS.15            |
@@ -57,7 +57,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 - [x] 1FD.25. `src/lib/types/contradiction.ts` — `ContradictionQueue`, `QueuedContradiction`, `DiegeticSurface`, `Resolution`, `HypothesisStrain` (doc 06 §4.4–§4.6, §5 verbatim; `HypothesisStrain` is the canonical strain type per doc 12 §2.15; all six `DiegeticSurface` channels typed though MVP drives only `impossible-artefact`/`field-report` — doc 07 §5.2's NPC generators already return the other shapes; `ContradictionQueue` shaped per doc 06, with doc 08 §3.4's bare-`Contradiction`-push store sketch JSDoc-flagged as illustrative pseudo-code to reconcile at the store task; `Resolution.contradictionId` flagged as a doc 06 forward reference — `Contradiction` members carry no `id` at MVP, the identity scheme belongs to the detection engine (7CD.x); resolves the two cross-file `TODO(1FD.25)` stand-ins in `interpretation.ts`; `ContradictionSeverity` already landed with 1FD.24)
 - [x] 1FD.27. `src/lib/types/career.ts` — `RoleRequirement`, `DisseminationCareerEffect`, `PeerReviewCareerEvent`, `ReviewerFeedback` (doc 07 §3.2–§3.3, §4.2 verbatim; `DisseminationTransition` hoisted from §3.2 per the `ContradictionSeverity` precedent and scoped to MVP's three live transitions — `published-to-collected` dropped per the 1FD.22 `DisseminationState` precedent; authored `ReputationEffect` hoist for the `{dimension, delta, basis}` shape doc 07 inlines identically on both career-event types; doc 08 §5's singular `reputationEffect` read in the `resolvePeerReview` sketch JSDoc-flagged — doc 07's plural array governs; `ActivityOutcome`'s provisional note updated now this task has landed, it stays provisional until activity execution gets an owning task per doc 13 §5; file remains import-free, cross-domain references by plain `string` id)
 - [x] 1FD.29. `src/lib/types/scholars.ts` — `MinimalScholar`, `NPCScholarSeed`, `SimulatedExcavation` (doc 07 §5.1 + doc 05 §4.1; `MinimalScholar.specialism.methodologicalBias` narrowed from the doc's `string` to interpretation.ts's `MethodologicalBias` union per the 1FD.31 register-narrowing precedent)
-- [ ] 1FD.30. `src/lib/types/corpus.ts` — `ProfessionalCorpus`, `FrequencyRecord`, `ContextFrequency`, `ConsensusStatement`, `Debate`, `DebatePosition`, `CoverageBudget`
+- [x] 1FD.30. `src/lib/types/corpus.ts` — `ProfessionalCorpus`, `FrequencyRecord`, `ContextFrequency`, `ConsensusStatement`, `Debate`, `DebatePosition`, `CoverageBudget` (doc 05 §4.2–§4.3 verbatim; `ContextFrequency` is named by `ProfessionalCorpus.contextAssociations` but shaped nowhere — authored provisional per the `MotifSet`/`ActivityOutcome`/`ProvenancePresentation` precedent, as the reverse index of `FrequencyRecord.byContext` — `{totalObserved, byCulture, associatedMaterials, associatedForms, lastUpdated}` — to firm up at 2GN.53, the first real producer; `SiteType` imported from world.ts per the scholars.ts precedent; cross-domain references — NPC ids, document node ids, culture ids, period ids — stay plain `string` per the career.ts convention)
 - [ ] 1FD.33. `src/lib/types/save.ts` — `SaveFile`, `SerialisedWorldState`, `SerialisedInterpretiveModel`, `SerialisedTermState`, `CURRENT_SAVE_VERSION`
 - [ ] 1FD.40. `src/lib/types/venues.ts` — `VenueTemporalProfile` (doc 10 §6.4, week-denominated: `submissionMode`, `openWeeks`, `cycleLengthWeeks`, `reviewLeadTimeWeeks`, `publicationLeadTimeWeeks`); reconcile with doc 07 §3.1's term-denominated `TemporalMode`/`SubmissionWindow` (supersede or coexist — doc 12's week-conversion sweep suggests weeks are canonical, cf. §2.9 precedent) and record the resolution in doc 12; consumed downstream by 9CR.5 (venue generation sets temporal properties) and 9CR.22 (venue cycles at term boundaries) — **depends on 1FD.23**
 
@@ -697,10 +697,10 @@ graph TD
     1FD.27["`*1FD.27*<br/>types/career effects`"]:::done
     1FD.28["`*1FD.28*<br/>types/term.ts`"]:::done
     1FD.29["`*1FD.29*<br/>types/scholars.ts`"]:::done
-    1FD.30["`*1FD.30*<br/>types/corpus.ts`"]:::open
+    1FD.30["`*1FD.30*<br/>types/corpus.ts`"]:::done
     1FD.31["`*1FD.31*<br/>types/description.ts`"]:::done
     1FD.32["`*1FD.32*<br/>types/visibility.ts`"]:::done
-    1FD.33["`*1FD.33*<br/>types/save.ts`"]:::blocked
+    1FD.33["`*1FD.33*<br/>types/save.ts`"]:::open
     1FD.34["`*1FD.34*<br/>Configure deno test`"]:::done
     1FD.35["`*1FD.35*<br/>Test fixture helpers (partial)`"]:::open
     1FD.36["`*1FD.36*<br/>Explorer route + layout`"]:::done

--- a/src/lib/types/corpus.ts
+++ b/src/lib/types/corpus.ts
@@ -1,0 +1,139 @@
+/**
+ * Professional corpus type definitions (doc 05 §4.2–§4.3).
+ *
+ * The corpus is the aggregated output of all simulated NPC research: what the field "knows" at
+ * game start. It is deliberately imperfect — coverage gaps leave whole cultures and site types
+ * undocumented (§4.2), and calibrated wrongness (§4.5) targets ~70% broadly correct, ~30%
+ * interestingly wrong, with errors concentrated in interpretive claims, absence claims, rarity
+ * assessments and cross-cultural relationships.
+ *
+ * The corpus is one of the two comparison sources for the agent-generic contradiction detector
+ * (doc 06 §4.3), alongside the world state's occluded properties. Corpus contradictions surface
+ * through peer channels and don't always mean the agent is wrong — the corpus can itself be wrong,
+ * and the player must decide whether to defer to authority or trust their own evidence.
+ *
+ * Generation lands at 2GN.50–2GN.55 (`engine/generation/corpus.ts`). This module is data shapes
+ * only, no behaviour. Cross-domain references (NPC ids, document node ids, culture ids, period
+ * ids) are plain `string` per the career.ts convention.
+ */
+
+import type { SiteType } from './world.ts';
+
+/**
+ * Controls how unevenly simulated research attention is distributed across the world (doc 05
+ * §4.2). Coverage biases are archaeologically authentic: large, urban, monumental cultures attract
+ * more research; burials and temples get excavated before rubbish heaps. The resulting gaps are
+ * the player's opportunity space.
+ */
+export interface CoverageBudget {
+	totalExcavations: number;
+
+	/** Prominent cultures get more attention. Keyed by culture id. */
+	cultureBias: Map<string, number>;
+
+	/** Burials/monuments over middens/workshops. */
+	siteTypeBias: Map<SiteType, number>;
+
+	/** Later periods better documented. Keyed by period id. */
+	periodBias: Map<string, number>;
+
+	/** Guaranteed undocumented site types per culture. */
+	minimumGapPerCulture: number;
+}
+
+/**
+ * What the field "knows" at game start (doc 05 §4.3) — the aggregated output of all simulated
+ * NPC research. The player encounters it as reference works, active debates, bibliographies and
+ * conspicuous absences (doc 05 §4.4).
+ */
+export interface ProfessionalCorpus {
+	/** Keyed by material id. */
+	materialFrequencies: Map<string, FrequencyRecord>;
+
+	/** Keyed by form id. */
+	formFrequencies: Map<string, FrequencyRecord>;
+
+	/** Keyed by context tag. */
+	contextAssociations: Map<string, ContextFrequency>;
+
+	activeDebates: Debate[];
+	receivedWisdom: ConsensusStatement[];
+}
+
+/**
+ * The corpus's record of how often a material or form has been observed (doc 05 §4.3).
+ * `consensusRarity` is the field's belief, not ground truth — rarity assessments are one of the
+ * calibrated wrongness channels (doc 05 §4.5).
+ */
+export interface FrequencyRecord {
+	totalObserved: number;
+
+	/** Keyed by context tag. */
+	byContext: Map<string, number>;
+
+	/** Keyed by culture id. */
+	byCulture: Map<string, number>;
+
+	consensusRarity: 'ubiquitous' | 'common' | 'uncommon' | 'rare' | 'unique';
+
+	/** Term index of most recent update. */
+	lastUpdated: number;
+}
+
+/**
+ * PROVISIONAL — named by `ProfessionalCorpus.contextAssociations` (doc 05 §4.3) but shaped
+ * nowhere in the docs. Authored here as the reverse index of `FrequencyRecord.byContext`: where
+ * a `FrequencyRecord` answers "in which contexts does this material/form appear?", a
+ * `ContextFrequency` answers "which materials/forms appear in this context?". Firms up at 2GN.53
+ * (`aggregateCorpus`), the first real producer.
+ */
+export interface ContextFrequency {
+	totalObserved: number;
+
+	/** Keyed by culture id. */
+	byCulture: Map<string, number>;
+
+	/** Keyed by material id. */
+	associatedMaterials: Map<string, number>;
+
+	/** Keyed by form id. */
+	associatedForms: Map<string, number>;
+
+	/** Term index of most recent update, mirroring `FrequencyRecord`. */
+	lastUpdated: number;
+}
+
+/**
+ * A claim the field treats as settled, to some degree (doc 05 §4.3). Presented to the player as
+ * established fact via reference works — which is exactly how calibrated wrongness propagates.
+ */
+export interface ConsensusStatement {
+	claim: string;
+	confidence: 'established' | 'accepted' | 'debated' | 'speculative';
+
+	/** Document node ids (doc 10). */
+	supportingPublications: string[];
+
+	/** Document node ids (doc 10). */
+	challengingPublications: string[];
+}
+
+/**
+ * An unsettled question where NPCs disagree (doc 05 §4.3). The player can read all positions and
+ * eventually weigh in.
+ */
+export interface Debate {
+	topic: string;
+	positions: DebatePosition[];
+}
+
+/** One NPC's stance in a debate (doc 05 §4.3). */
+export interface DebatePosition {
+	/** References an NPC scholar (scholars.ts) by id. */
+	npcId: string;
+
+	stance: string;
+
+	/** Document node or artefact ids the position rests on. */
+	evidence: string[];
+}

--- a/src/lib/types/venues.ts
+++ b/src/lib/types/venues.ts
@@ -11,12 +11,14 @@
  * a tier. Venues are static once generated for MVP — shifting attributes (reputation damage,
  * editorial turnover, scope drift) are deferred post-MVP (doc 11).
  *
- * Known spec tension: `TemporalMode` here is term-denominated per doc 07 §3.1, while doc 10 §6.4
- * defines a separate week-denominated `VenueTemporalProfile` covering overlapping ground
- * (submission windows, lead times). Doc 12 records doc 10's week conversion but no reconciliation
- * with doc 07; roadmap task 1FD.40 owns `VenueTemporalProfile` and the reconciliation. Doc 07's
- * shapes are transcribed as written, save the `methodologicalLeaning` narrowing noted on the
- * field. This module is data shapes only, no behaviour.
+ * Temporal model: doc 10 §6.4's week-denominated `VenueTemporalProfile` is canonical (doc 12
+ * §2.17). Doc 07 §3.1's term-denominated `TemporalMode`/`SubmissionWindow` are superseded — the
+ * doc 12 §2.9 week-conversion sweep updated doc 10's profile but never doc 07, and the landed
+ * `PeerReviewState` (documents.ts, 1FD.22) already works in absolute weeks. `visibilityWindow`,
+ * the one doc 07 temporal field with no doc 10 equivalent, is deferred post-MVP per the
+ * `presented`/`collected` `DisseminationState` precedent — no task or doc consumes it. Doc 07's
+ * remaining shapes are transcribed as written, save the `methodologicalLeaning` narrowing noted
+ * on the field. This module is data shapes only, no behaviour.
  */
 
 import type { MethodologicalBias } from './interpretation.ts';
@@ -35,37 +37,31 @@ export type ContainerModel =
 	| 'event';
 
 /**
- * When a venue accepts submissions (doc 07 §3.1). Seasonal windows create calendar pressure: the
- * player must decide whether to rush a document to meet a window or wait for the next cycle.
+ * When a venue accepts and publishes work (doc 10 §6.4). Seasonal windows create calendar
+ * pressure: the player must decide whether to rush a document to meet a window or wait for the
+ * next cycle; rolling venues are always open but may have longer review times. Lead times are
+ * stored in weeks for verisimilitude — the player sees "expected review: 16–24 weeks" — but
+ * resolution occurs at term boundaries, because that's when the world ticks (doc 08 §3.6). Set
+ * per-venue at world generation (9CR.5) and observable: the player can check submission
+ * deadlines. Weeks-within-year values tie to `WEEKS_PER_YEAR` (term.ts, 1FD.28).
  */
-export interface SubmissionWindow {
-	/** Windows per year (1 = annual, 3 = termly, etc.). */
-	frequency: number;
+export interface VenueTemporalProfile {
+	/** Self-referential when the profile is embedded in `VenueDefinition`. */
+	venueId: string;
 
-	/** How windows align with the academic calendar, if they do. */
-	alignment?: 'term-start' | 'term-end' | 'annual' | 'event-tied';
+	submissionMode: 'rolling' | 'seasonal';
 
-	/**
-	 * Whether a window is currently open. Runtime-derived state sitting inside an otherwise static
-	 * definition (transcribed verbatim from doc 07 §3.1); doc 10 §6.4's schedule-based
-	 * `VenueTemporalProfile` derives openness from the current week instead, and 1FD.40's
-	 * reconciliation owns this field's fate. Consumers should derive window status from the
-	 * current term rather than trusting a stored flag.
-	 */
-	open: boolean;
-}
+	/** Seasonal venues only: ranges of weeks-within-year (0–47) when submissions are accepted. */
+	openWeeks?: [number, number][];
 
-/**
- * When and how often a venue accepts and publishes work (doc 07 §3.1).
- */
-export interface TemporalMode {
-	submissionWindow: SubmissionWindow;
+	/** Seasonal venues only: period of the cycle (e.g. 48 = annual). */
+	cycleLengthWeeks?: number;
 
-	/** Terms between acceptance and publication (1–3 typical). */
-	leadTime: number;
+	/** Min–max weeks from submission to decision. */
+	reviewLeadTimeWeeks: [number, number];
 
-	/** Terms the work remains "current" before fading into the backlist. */
-	visibilityWindow: number | 'indefinite';
+	/** Weeks from acceptance to formal publication. */
+	publicationLeadTimeWeeks: number;
 }
 
 /**
@@ -121,7 +117,7 @@ export interface VenueDefinition {
 
 	// Structural properties — how publication works here
 	containerModel: ContainerModel;
-	temporalMode: TemporalMode;
+	temporalProfile: VenueTemporalProfile;
 
 	/** Whether the audience encounters actual artefacts alongside the work. */
 	artefactSituated: boolean;


### PR DESCRIPTION
## Overview

Two Milestone 1 foundation tasks, both on the type layer.

**1FD.30** adds `src/lib/types/corpus.ts`: the shapes for the professional corpus, which is everything the academic field believes at game start. The six doc 05 shapes are transcribed verbatim. `ContextFrequency` is named in the spec but shaped nowhere, so it lands as a flagged provisional type (the reverse index of `FrequencyRecord.byContext`) to firm up when corpus aggregation is built at 2GN.53.

**1FD.40** settles a spec conflict in `src/lib/types/venues.ts`. Doc 07 described venue submission timing in terms; doc 10 described it in weeks. Weeks are the canonical timestamp (doc 12 §2.9), so doc 10's `VenueTemporalProfile` supersedes doc 07's `TemporalMode` and `SubmissionWindow`, which are removed. `visibilityWindow` had no consumer anywhere and is deferred post-MVP. The resolution is recorded as doc 12 §2.17 with a supersession note in doc 07.

Milestone 1 now has a single open task: 1FD.33 (`save.ts`), the last blocker before the m1B checkpoint and the Explorer type index panel.

## Summary

A village of gossiping librarians has written down everything they believe about their neighbours, got roughly a third of it confidently wrong and filed the lot as established fact. This PR builds the filing cabinet. Meanwhile the town's two clock towers disagreed about whether time is measured in school terms or in weeks, so we demolished the wrong one and noted the demolition in the parish records.

> [!TIP]
> Nothing to do after pulling this down. Type-only changes, no new dependencies, no task or config changes.

---

## Changes

<details>
<summary><strong>New: <code>src/lib/types/corpus.ts</code> (1FD.30)</strong></summary>

- `CoverageBudget`: how unevenly simulated research attention is distributed (doc 05 §4.2)
- `ProfessionalCorpus`, `FrequencyRecord`, `ConsensusStatement`, `Debate`, `DebatePosition`: doc 05 §4.3 verbatim
- `ContextFrequency`: authored provisional, JSDoc-flagged, firms up at 2GN.53
- `SiteType` imported from `world.ts`; all other cross-domain references stay plain `string` ids

</details>

<details>
<summary><strong>Changed: <code>src/lib/types/venues.ts</code> (1FD.40)</strong></summary>

- `VenueTemporalProfile` added verbatim from doc 10 §6.4: `submissionMode`, `openWeeks`, `cycleLengthWeeks`, `reviewLeadTimeWeeks`, `publicationLeadTimeWeeks`
- `TemporalMode` and `SubmissionWindow` removed; `VenueDefinition.temporalMode` becomes `temporalProfile`
- `visibilityWindow` dropped for MVP per the `presented`/`collected` precedent
- Module JSDoc rewritten from "known spec tension" to the resolution record

⚠️ Removes two exported types. Nothing consumed them; pre-1.0.

</details>

<details>
<summary><strong>Design docs</strong></summary>

- `docs/12-propagation-register.md`: new §2.17 entry (Venue Temporal Model: Weeks Canonical) with rationale and change table
- `docs/07-career-social-systems.md`: supersession note under the §3.1 temporal block

</details>

<details>
<summary><strong>Roadmap</strong></summary>

- 1FD.30 and 1FD.40 ticked with landing annotations
- FD next-up now reads 1FD.33 alone; progress map classes flipped (1FD.30 and 1FD.40 done, 1FD.33 unblocked)

</details>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added professional corpus data structures for coverage, frequency, consensus, and debate information.
  - Introduced a week-based venue timing model with submission, review, and publication scheduling details.
  - Updated venue definitions to use the new temporal profile.

- **Documentation**
  - Clarified the transition from term-based venue timing to week-based scheduling.
  - Updated propagation records and MVP roadmap progress, including completed type-system milestones and remaining save-related work.
  - Documented that venue visibility windows are deferred beyond the MVP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->