### PR TITLE
Geometric Primitive Definitions for Artefact Generation

### DIFF
--- a/docs/roadmaps/mvp.md
+++ b/docs/roadmaps/mvp.md
@@ -7,7 +7,7 @@ description: MVP implementation roadmap from foundation through NPC social syste
 |          | Status                  | Next Up           | Blocked           |
 | -------- | ----------------------- | ----------------- | ----------------- |
 | **FD**   | Complete                | —      | — |
-| **GN**   | Not started             | 2GN.1, 2GN.2, 2GN.17, 2GN.22 | —      |
+| **GN**   | In progress             | 2GN.2, 2GN.17, 2GN.22 | —      |
 | **WS**   | Not started             | —                 | 2GN.56            |
 | **UI**   | Not started             | —                 | 3WS.15            |
 | **KN**   | Not started             | —                 | 4UI.6             |
@@ -126,7 +126,6 @@ description: MVP implementation roadmap from foundation through NPC social syste
 
 **Static data — primitives & grammar rules**
 
-- [ ] 2GN.1. `src/lib/data/grammars/primitives.ts` — geometric primitive defs (elongated, cylindrical, flat-broad, hollow-enclosed, ring-form, disc-form, bar-form, sheet-form) with parameter enums — **depends on 1FD.10**
 - [ ] 2GN.2. `src/lib/data/grammars/core.ts` — MVP component grammar rules: `<object>` → `<component-group>+`, `<component-group>` → `<primary-component>` + optional attachments, base weights — **depends on 1FD.10**
 
 **Component grammar engine**
@@ -232,6 +231,10 @@ description: MVP implementation roadmap from foundation through NPC social syste
 <a name="m2-blocked"><h4>Blocked (Milestone 2)</h4></a>
 
 <a name="m2-done"><h4>Completed (Milestone 2)</h4></a>
+
+**Static data — primitives & grammar rules**
+
+- [x] 2GN.1. `src/lib/data/grammars/primitives.ts` — geometric primitive defs (elongated, cylindrical, flat-broad, hollow-enclosed, ring-form, disc-form, bar-form, sheet-form) with parameter enums — **depends on 1FD.10** (doc 05 §5.3 transcribed verbatim as a single `as const` `PRIMITIVE_PARAMETERS` registry — primitive id → parameter name → ordered value list — with `PrimitiveType` derived via `keyof typeof`, a flagged deviation from the interfaces-first convention per the `Serialised<T>` zero-drift precedent in save.ts; "parameter enums" realised as string-literal value lists per the no-`enum` convention committed in artefact.ts; parameters deliberately scoped per primitive, no shared unions — `crossSection` and `taper` carry different value-sets across primitives; `PRIMITIVE_TYPES` array + `isPrimitiveType` guard round out the union-values-guard trio per the visibility.ts precedent; material-tag compatibility stays with 2GN.10, dimension derivation with 2GN.8, selection weights with 2GN.2/2GN.4 — this module is data only, no `MaterialTag` import needed; covered by 7 Deno tests asserting the eight-primitive vocabulary, per-primitive parameter names and verbatim spot-checked value lists)
 </details>
 
 <details>

--- a/src/lib/data/grammars/primitives.test.ts
+++ b/src/lib/data/grammars/primitives.test.ts
@@ -1,0 +1,78 @@
+/// <reference lib="deno.ns" />
+import { assert, assertEquals } from '@std/assert';
+import { isPrimitiveType, PRIMITIVE_PARAMETERS, PRIMITIVE_TYPES } from './primitives.ts';
+
+Deno.test('registry: contains exactly the eight primitives from doc 05 §5.3', () => {
+	assertEquals(Object.keys(PRIMITIVE_PARAMETERS), [
+		'elongated',
+		'cylindrical',
+		'flat-broad',
+		'hollow-enclosed',
+		'ring-form',
+		'disc-form',
+		'bar-form',
+		'sheet-form',
+	]);
+});
+
+Deno.test('registry: each primitive exposes the expected parameter names', () => {
+	const expected: Record<string, string[]> = {
+		'elongated': ['length', 'crossSection', 'taper', 'edge', 'point'],
+		'cylindrical': ['length', 'diameter', 'wall', 'opening', 'base'],
+		'flat-broad': ['shape', 'size', 'thickness', 'curvature', 'perforation'],
+		'hollow-enclosed': ['shape', 'size', 'wall', 'opening', 'base'],
+		'ring-form': ['diameter', 'crossSection', 'gap'],
+		'disc-form': ['diameter', 'thickness', 'perforation'],
+		'bar-form': ['length', 'crossSection', 'taper'],
+		'sheet-form': ['size', 'shape', 'flexibility'],
+	};
+
+	for (const [primitive, parameters] of Object.entries(PRIMITIVE_PARAMETERS)) {
+		assertEquals(Object.keys(parameters), expected[primitive], primitive);
+	}
+});
+
+Deno.test('registry: every parameter has a non-empty value list with no duplicates', () => {
+	for (const [primitive, parameters] of Object.entries(PRIMITIVE_PARAMETERS)) {
+		for (const [parameter, values] of Object.entries(parameters)) {
+			const label = `${primitive}.${parameter}`;
+			assert(values.length > 0, `${label} is empty`);
+			assertEquals(values.length, new Set(values).size, `${label} has duplicates`);
+		}
+	}
+});
+
+Deno.test('registry: value lists match the doc 05 §5.3 spec verbatim (spot checks)', () => {
+	assertEquals(PRIMITIVE_PARAMETERS['elongated'].crossSection, [
+		'round',
+		'oval',
+		'rectangular',
+		'triangular',
+		'diamond',
+	]);
+	assertEquals(PRIMITIVE_PARAMETERS['disc-form'].perforation, ['none', 'central', 'off-centre']);
+	assertEquals(PRIMITIVE_PARAMETERS['hollow-enclosed'].opening, ['wide', 'narrow', 'slit', 'none']);
+	assertEquals(PRIMITIVE_PARAMETERS['bar-form'].taper, ['none', 'single-end', 'both-ends']);
+	assertEquals(PRIMITIVE_PARAMETERS['ring-form'].gap, ['closed', 'open', 'overlapping']);
+	assertEquals(PRIMITIVE_PARAMETERS['sheet-form'].flexibility, [
+		'rigid',
+		'semi-flexible',
+		'flexible',
+	]);
+});
+
+Deno.test('PRIMITIVE_TYPES: matches the registry keys exactly', () => {
+	assertEquals([...PRIMITIVE_TYPES], Object.keys(PRIMITIVE_PARAMETERS));
+});
+
+Deno.test('isPrimitiveType: accepts all eight primitive ids', () => {
+	for (const primitive of PRIMITIVE_TYPES) {
+		assert(isPrimitiveType(primitive), primitive);
+	}
+});
+
+Deno.test('isPrimitiveType: rejects non-primitive strings', () => {
+	assert(!isPrimitiveType('artefact'));
+	assert(!isPrimitiveType(''));
+	assert(!isPrimitiveType('Elongated'));
+});

--- a/src/lib/data/grammars/primitives.ts
+++ b/src/lib/data/grammars/primitives.ts
@@ -1,0 +1,106 @@
+/**
+ * Geometric primitive definitions (doc 05 §5.3).
+ *
+ * The eight physical forms every artefact component is built from, each with its parameter
+ * vocabulary transcribed verbatim from the component grammar's BNF. Primitives are geometric, not
+ * functional (doc 05 §5.1): the grammar knows about elongated forms and hollow enclosures, never
+ * swords or pots — classification is entirely downstream. Parameters are scoped per primitive, not
+ * shared: `crossSection` on an elongated form admits different values from `crossSection` on a
+ * ring-form, so no global parameter unions exist here.
+ *
+ * This module is static data only, no behaviour. Grammar expansion resolves leaf primitives
+ * against this registry (`expandGrammar`, roadmap 2GN.3); the material-compatibility table that
+ * maps primitive + properties to `allowedMaterialTags` is engine logic (roadmap 2GN.10), and
+ * dimension derivation happens at normalisation (roadmap 2GN.8) — neither lives here.
+ *
+ * The registry is a single `as const` value with the type layer derived from it — a deliberate
+ * deviation from the interfaces-first convention, per the `Serialised<T>` precedent in
+ * `types/save.ts`: one source of truth means the types cannot drift from the data.
+ */
+
+/**
+ * Parameter vocabularies for the eight geometric primitives, keyed by primitive id then parameter
+ * name (doc 05 §5.3, verbatim). Each value list is ordered as the BNF lists it.
+ */
+export const PRIMITIVE_PARAMETERS = {
+	/** Long-axis forms: blades, pins, shafts, handles. */
+	'elongated': {
+		length: ['short', 'medium', 'long'],
+		crossSection: ['round', 'oval', 'rectangular', 'triangular', 'diamond'],
+		taper: ['none', 'gradual', 'abrupt'],
+		edge: ['none', 'single', 'double'],
+		point: ['none', 'sharp', 'blunt'],
+	},
+	/** Tubular forms with an interior: beakers, sockets, ferrules. */
+	'cylindrical': {
+		length: ['short', 'medium', 'long'],
+		diameter: ['narrow', 'medium', 'wide'],
+		wall: ['thin', 'medium', 'thick'],
+		opening: ['open', 'restricted', 'closed'],
+		base: ['flat', 'rounded', 'pointed'],
+	},
+	/** Broad planar forms: blades of another kind, plaques, palettes. */
+	'flat-broad': {
+		shape: ['round', 'oval', 'rectangular', 'irregular', 'crescent'],
+		size: ['small', 'medium', 'large'],
+		thickness: ['thin', 'medium', 'thick'],
+		curvature: ['flat', 'shallow', 'deep'],
+		perforation: ['none', 'single', 'multiple'],
+	},
+	/** Volumetric containers: vessels, boxes, flasks. */
+	'hollow-enclosed': {
+		shape: ['spherical', 'ovoid', 'box', 'irregular'],
+		size: ['small', 'medium', 'large'],
+		wall: ['thin', 'medium', 'thick'],
+		opening: ['wide', 'narrow', 'slit', 'none'],
+		base: ['flat', 'rounded', 'pedestal'],
+	},
+	/** Annular forms: rings, torcs, loops. */
+	'ring-form': {
+		diameter: ['small', 'medium', 'large'],
+		crossSection: ['round', 'flat', 'twisted'],
+		gap: ['closed', 'open', 'overlapping'],
+	},
+	/** Solid circular planar forms: whorls, weights, mirrors. */
+	'disc-form': {
+		diameter: ['small', 'medium', 'large'],
+		thickness: ['thin', 'medium', 'thick'],
+		perforation: ['none', 'central', 'off-centre'],
+	},
+	/** Solid straight stock: ingots, rods, awl bodies. */
+	'bar-form': {
+		length: ['short', 'medium', 'long'],
+		crossSection: ['round', 'square', 'hexagonal'],
+		taper: ['none', 'single-end', 'both-ends'],
+	},
+	/** Thin covering forms: fittings, facings, wrappings. */
+	'sheet-form': {
+		size: ['small', 'medium', 'large'],
+		shape: ['rectangular', 'triangular', 'irregular', 'fitted'],
+		flexibility: ['rigid', 'semi-flexible', 'flexible'],
+	},
+} as const;
+
+/**
+ * The eight primitive ids — the `<primary-component>` alternatives of doc 05 §5.3. Matches
+ * `NormalisedComponent.primitiveType` (`types/artefact.ts`), which stays a plain `string` at the
+ * type boundary; this union is the data-layer vocabulary behind it.
+ */
+export type PrimitiveType = keyof typeof PRIMITIVE_PARAMETERS;
+
+/**
+ * All primitive ids, in the order doc 05 §5.3 lists them. Supports iteration and runtime
+ * validation without hand-maintaining a second copy of the eight literals.
+ */
+export const PRIMITIVE_TYPES: readonly PrimitiveType[] = Object.keys(
+	PRIMITIVE_PARAMETERS,
+) as PrimitiveType[];
+
+/**
+ * Narrows an arbitrary string to `PrimitiveType`. The minimal runtime counterpart to the type,
+ * for boundaries where a primitive id arrives untyped (grammar rule `expandsTo` resolution,
+ * roadmap 2GN.3; save data).
+ */
+export function isPrimitiveType(value: string): value is PrimitiveType {
+	return (PRIMITIVE_TYPES as readonly string[]).includes(value);
+}


### PR DESCRIPTION
## Overview

First task of Milestone 2 (2GN.1). This adds the vocabulary of eight geometric primitives that every generated artefact component will be built from: elongated, cylindrical, flat-broad, hollow-enclosed, ring-form, disc-form, bar-form and sheet-form, each with its parameter value-sets transcribed verbatim from doc 05 §5.3.

The registry is a single `as const` value with the type layer derived from it, so the types cannot drift from the data. Parameters are scoped per primitive: `crossSection` on an elongated form admits different values from `crossSection` on a ring-form, so no shared unions exist. Material compatibility (2GN.10), dimension derivation (2GN.8) and selection weights (2GN.2/2GN.4) are deliberately out of scope.

Contributes toward #4, which structure generation (2GN.3) will close.

## Summary

A crate of Lego bricks delivered to an empty workshop. Nobody has built anything yet and there are no instructions, but the bricks are sorted into eight labelled drawers, every drawer's contents match the catalogue exactly and a clipboard-wielding inspector has counted each compartment twice.

> [!TIP]
> Nothing to do after pulling. No new dependencies, no config changes, no migrations.

---

## Changes

<details>
<summary><code>src/lib/data/grammars/primitives.ts</code> (new)</summary>

- Creates `src/lib/data/` and `grammars/`, the static-data layer reserved in doc 08's directory structure
- `PRIMITIVE_PARAMETERS`: the eight primitives keyed by id, then parameter name, then ordered value list, verbatim from doc 05 §5.3 (including `off-centre` on disc-form)
- `PrimitiveType` derived via `keyof typeof`, with `PRIMITIVE_TYPES` array and `isPrimitiveType` guard following the `visibility.ts` union-values-guard pattern
- Data only, no behaviour; module JSDoc forward-references the engine tasks that consume it

</details>

<details>
<summary><code>src/lib/data/grammars/primitives.test.ts</code> (new)</summary>

- 7 Deno tests: the eight-primitive vocabulary, per-primitive parameter names, duplicate-free non-empty value lists, verbatim spot-checks against the spec and both directions of the type guard
- Full suite now 49 tests, all passing; `deno task check`, `deno fmt --check` and `deno lint` clean on the new files

</details>

<details>
<summary><code>docs/roadmaps/mvp.md</code></summary>

- 2GN.1 moved to Completed (Milestone 2) with an implementation annotation in the established style
- Status table: GN row flipped to In progress, next up 2GN.2, 2GN.17 and 2GN.22

</details>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
